### PR TITLE
Remove previous zip before add new files

### DIFF
--- a/app/models/work_paper.rb
+++ b/app/models/work_paper.rb
@@ -110,10 +110,9 @@ class WorkPaper < ApplicationRecord
   end
 
   def create_cover_and_zip
-    self.file_model.try(:file?).tap do |file|
-      self.create_pdf_cover if @cover_must_be_created && file
-      self.create_zip if @zip_must_be_created || (@cover_must_be_created && file)
-    end
+    self.file_model.try(:file?) &&
+      (@zip_must_be_created || @cover_must_be_created) &&
+      create_zip
 
     true
   end
@@ -221,7 +220,10 @@ class WorkPaper < ApplicationRecord
 
     self.create_pdf_cover
 
+
     if File.file?(original_filename) && File.file?(pdf_filename)
+      FileUtils.rm_f zip_filename
+
       Zip::File.open(zip_filename, Zip::File::CREATE) do |zipfile|
         zipfile.add(self.filename_with_prefix, original_filename) { true }
         zipfile.add(File.basename(pdf_filename), pdf_filename) { true }

--- a/app/models/work_paper.rb
+++ b/app/models/work_paper.rb
@@ -220,9 +220,8 @@ class WorkPaper < ApplicationRecord
 
     self.create_pdf_cover
 
-
     if File.file?(original_filename) && File.file?(pdf_filename)
-      FileUtils.rm_f zip_filename
+      FileUtils.rm zip_filename if File.exists?(zip_filename)
 
       Zip::File.open(zip_filename, Zip::File::CREATE) do |zipfile|
         zipfile.add(self.filename_with_prefix, original_filename) { true }

--- a/app/views/work_papers/_work_paper.html.erb
+++ b/app/views/work_papers/_work_paper.html.erb
@@ -24,6 +24,7 @@
             <%= link_to_upload fm_f.object %>
             <% if fm_f.object.file_cache %>
               <%= fm_f.input :file_cache, as: :hidden %>
+              <%= fm_f.input :file, as: :hidden %>
             <% else %>
               <%= fm_f.input :file, label: false %>
             <% end %>

--- a/app/views/work_papers/_work_paper.html.erb
+++ b/app/views/work_papers/_work_paper.html.erb
@@ -24,7 +24,7 @@
             <%= link_to_upload fm_f.object %>
             <% if fm_f.object.file_cache %>
               <%= fm_f.input :file_cache, as: :hidden %>
-              <%= fm_f.input :file, as: :hidden %>
+              <%= fm_f.input :file, as: :hidden, input_html: { value: nil } %>
             <% else %>
               <%= fm_f.input :file, label: false %>
             <% end %>


### PR DESCRIPTION
- Remove the previous zip file in case of same name file is uploaded
- Skip double call to `create_pdf_cover`