### PR TITLE
ASync report zipfile as temp

### DIFF
--- a/app/mailers/report_mailer.rb
+++ b/app/mailers/report_mailer.rb
@@ -9,11 +9,11 @@ class ReportMailer < ActionMailer::Base
     @user = User.find user_id
     organization = Organization.find organization_id
 
-    attachments[filename] = { mime_type: 'application/zip', content: file }
+    attachments[filename] = { mime_type: 'application/zip', content: File.read(file) }
 
     mail(
       to: @user.email,
-      subject: I18n.t('report_mailer.csv.subject', organization: organization.prefix.upcase)
+      subject: I18n.t('report_mailer.attached_report.subject', organization: organization.prefix.upcase)
     )
   end
 end

--- a/config/initializers/email.rb
+++ b/config/initializers/email.rb
@@ -15,4 +15,4 @@ Rails.application.configure do
   }
 end
 
-ActionMailer::Base.register_observer MailObserver
+ActionMailer::Base.register_observer ::MailObserver

--- a/lib/mail_observer.rb
+++ b/lib/mail_observer.rb
@@ -1,4 +1,4 @@
-class MailObserver
+class ::MailObserver
   def self.delivered_email(message)
     organization = Organization.find_by_prefix(
       message.subject.match(/\[(\w+\W*\w*)\]/)[1].downcase


### PR DESCRIPTION
- En vez de hacerlo en memoria, zippeamos a un archivo y lo pasamos al mailer.
- Nota: Usamos   `Dir::Tmpname`  en vez de `Tempfile` porque Tempfile limpia cuando "termina" el proceso.