### PR TITLE
Alternative LDAP server

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -71,7 +71,7 @@ class OrganizationsController < ApplicationController
           :username_attribute, :name_attribute, :last_name_attribute,
           :email_attribute, :function_attribute, :roles_attribute,
           :manager_attribute, :test_user, :test_password,
-          :user, :password
+          :user, :password, :alternative_hostname, :alternative_port
         ]
       )
     end

--- a/app/models/concerns/ldap_configs/ldap.rb
+++ b/app/models/concerns/ldap_configs/ldap.rb
@@ -22,7 +22,7 @@ module LdapConfigs::Ldap
   def alternative_ldap
     return unless try_alternative_ldap?
 
-    @alternative_ldap = true
+    @using_alternative_ldap = true
 
     dup.tap do |alternative|
       alternative.hostname = alternative.alternative_hostname
@@ -31,7 +31,7 @@ module LdapConfigs::Ldap
   end
 
   def try_alternative_ldap?
-    alternative_hostname.present? && @alternative_ldap.nil?
+    alternative_hostname.present? && @using_alternative_ldap.blank?
   end
 
   private

--- a/app/models/concerns/ldap_configs/ldap.rb
+++ b/app/models/concerns/ldap_configs/ldap.rb
@@ -19,6 +19,21 @@ module LdapConfigs::Ldap
     match ? match[1] : username
   end
 
+  def alternative_ldap
+    return unless try_alternative_ldap?
+
+    @alternative_ldap = true
+
+    dup.tap do |alternative|
+      alternative.hostname = alternative.alternative_hostname
+      alternative.port     = alternative.alternative_port
+    end
+  end
+
+  def try_alternative_ldap?
+    alternative_hostname.present? && @alternative_ldap.nil?
+  end
+
   private
 
     def username_for username

--- a/app/models/concerns/ldap_configs/validation.rb
+++ b/app/models/concerns/ldap_configs/validation.rb
@@ -8,11 +8,14 @@ module LdapConfigs::Validation
       :login_mask, :username_attribute, :name_attribute,
       :last_name_attribute, :email_attribute, :roles_attribute,
       presence: true
+    validates :alternative_hostname, presence: true, if: :alternative_port?
     validates :test_user, :test_password, presence: true, unless: :user?
     validates :hostname, :basedn, :filter, :login_mask, :username_attribute,
       :name_attribute, :last_name_attribute, :email_attribute,
       :roles_attribute, length: { maximum: 255 }
     validates :port, numericality: { only_integer: true, greater_than: 0, less_than: 65536 }
+    validates :alternative_port, numericality: { only_integer: true, greater_than: 0, less_than: 65536 },
+      if: :alternative_hostname?
     validates :basedn, format: /\A(\w+=[\w-]+)(,\w+=[\w-]+)*\z/
     validates :username_attribute, :name_attribute, :last_name_attribute,
       :email_attribute, :function_attribute, :roles_attribute,
@@ -39,5 +42,13 @@ module LdapConfigs::Validation
 
     def user?
       user.present?
+    end
+
+    def alternative_port?
+      alternative_port.present?
+    end
+
+    def alternative_hostname?
+      alternative_hostname.present?
     end
 end

--- a/app/services/authentication.rb
+++ b/app/services/authentication.rb
@@ -100,7 +100,13 @@ class Authentication
         @redirect_url = @session[:go_to] || { controller: 'welcome', action: 'index' }
       end
     rescue Net::LDAP::Error
-      @message = I18n.t 'message.ldap_error'
+      if @ldap_config.try_alternative_ldap?
+        @ldap_config = @ldap_config.alternative_ldap
+
+        retry
+      end
+
+      @message = I18n.t('message.ldap_error')
     end
 
     def choose_ldap_config username

--- a/app/views/organizations/_ldap_config.html.erb
+++ b/app/views/organizations/_ldap_config.html.erb
@@ -21,6 +21,8 @@
           <div class="col-md-6">
             <%= l_f.input :hostname %>
             <%= l_f.input :port %>
+            <%= l_f.input :alternative_hostname %>
+            <%= l_f.input :alternative_port %>
             <%= l_f.input :basedn %>
             <%= l_f.input :filter %>
             <%= l_f.input :login_mask %>

--- a/config/locales/models.es.yml
+++ b/config/locales/models.es.yml
@@ -340,6 +340,8 @@ es:
       ldap_config:
         hostname: 'Dirección del servidor'
         port: 'Puerto'
+        alternative_hostname: 'Dirección del servidor alternativo'
+        alternative_port: 'Puerto alternativo'
         basedn: 'Nombre distinguido de base'
         filter: 'Filtro'
         login_mask: 'Máscara de autenticación'

--- a/config/locales/simple_form.es.yml
+++ b/config/locales/simple_form.es.yml
@@ -33,6 +33,8 @@ es:
       ldap_config:
         hostname: 'Dominio o dirección IP'
         port: 'Por ejemplo: 389'
+        alternative_hostname: 'Dominio o dirección IP'
+        alternative_port: 'Por ejemplo: 389'
         basedn: 'CN=Users,DC=dominio,DC=com'
         filter: 'CN=*'
         login_mask: '&#37;{user}@dominio.com, Dominio\&#37;{user} o &#37;{user},&#37;{basedn}'

--- a/db/migrate/20191107232734_add_alternative_ldap_columns.rb
+++ b/db/migrate/20191107232734_add_alternative_ldap_columns.rb
@@ -1,0 +1,8 @@
+class AddAlternativeLdapColumns < ActiveRecord::Migration[6.0]
+  def change
+    change_table :ldap_configs do |t|
+      t.string  :alternative_hostname
+      t.integer :alternative_port
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_09_001942) do
+ActiveRecord::Schema.define(version: 2019_11_07_232734) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
@@ -483,6 +483,8 @@ ActiveRecord::Schema.define(version: 2019_10_09_001942) do
     t.string "filter"
     t.string "user"
     t.string "encrypted_password"
+    t.string "alternative_hostname"
+    t.integer "alternative_port"
     t.index ["organization_id"], name: "index_ldap_configs_on_organization_id"
   end
 

--- a/test/controllers/organizations_controller_test.rb
+++ b/test/controllers/organizations_controller_test.rb
@@ -55,25 +55,27 @@ class OrganizationsControllerTest < ActionController::TestCase
     assert_difference ['Organization.count', 'LdapConfig.count'] do
       post :create, params: {
         organization: {
-          name: 'New organization',
-          prefix: 'new-prefix',
-          description: 'New description',
-          group_id: groups(:main_group).id,
+          name:                   'New organization',
+          prefix:                 'new-prefix',
+          description:            'New description',
+          group_id:               groups(:main_group).id,
           ldap_config_attributes: {
-            hostname: 'localhost',
-            port: ENV['TRAVIS'] ? 3389 : 389,
-            basedn: 'ou=people,dc=test,dc=com',
-            filter: 'CN=*',
-            login_mask: 'cn=%{user},%{basedn}',
-            username_attribute: 'cn',
-            name_attribute: 'givenname',
-            last_name_attribute: 'sn',
-            email_attribute: 'mail',
-            function_attribute: 'title',
-            roles_attribute: 'description',
-            manager_attribute: 'manager',
-            test_user: 'admin',
-            test_password: 'admin123'
+            hostname:             'localhost',
+            port:                 ldap_port,
+            basedn:               'ou=people,dc=test,dc=com',
+            filter:               'CN=*',
+            login_mask:           'cn=%{user},%{basedn}',
+            username_attribute:   'cn',
+            name_attribute:       'givenname',
+            last_name_attribute:  'sn',
+            email_attribute:      'mail',
+            function_attribute:   'title',
+            roles_attribute:      'description',
+            manager_attribute:    'manager',
+            test_user:            'admin',
+            test_password:        'admin123',
+            alternative_hostname: '127.0.0.1',
+            alternative_port:     ldap_port
           }
         }
       }

--- a/test/controllers/users/imports_controller_test.rb
+++ b/test/controllers/users/imports_controller_test.rb
@@ -21,6 +21,24 @@ class Users::ImportsControllerTest < ActionController::TestCase
     end
   end
 
+  test 'should create import with alternative ldap' do
+    ldap_config = Current.organization.ldap_config
+
+    ldap_config.update_columns(
+      hostname:             '0.0.0.1',
+      alternative_hostname: 'localhost',
+      alternative_port:     ldap_port
+    )
+
+    assert_difference 'User.count' do
+      post :create, params: {
+        import: { username: 'admin', password: 'admin123' }
+      }
+      assert_response :success
+      assert assigns(:imports).present?
+    end
+  end
+
   test 'should not create import' do
     assert_no_difference 'User.count' do
       post :create, params: {

--- a/test/models/ldap_config_test.rb
+++ b/test/models/ldap_config_test.rb
@@ -55,6 +55,20 @@ class LdapConfigTest < ActiveSupport::TestCase
     assert_error @ldap_config, :manager_attribute, :invalid
   end
 
+  test 'validates alternative fields' do
+    @ldap_config.alternative_port     = ldap_port
+    @ldap_config.alternative_hostname = ''
+
+    assert @ldap_config.invalid?
+    assert_error @ldap_config, :alternative_hostname, :blank
+
+    @ldap_config.alternative_hostname = 'localhost'
+    @ldap_config.alternative_port     = 'xx'
+
+    assert @ldap_config.invalid?
+    assert_error @ldap_config, :alternative_port, :not_a_number
+  end
+
   test 'validates port range' do
     @ldap_config.port = 0
 
@@ -65,6 +79,18 @@ class LdapConfigTest < ActiveSupport::TestCase
 
     assert @ldap_config.invalid?
     assert_error @ldap_config, :port, :less_than, count: 65536
+
+    @ldap_config.alternative_hostname = 'localhost'
+
+    @ldap_config.alternative_port = 0
+
+    assert @ldap_config.invalid?
+    assert_error @ldap_config, :alternative_port, :greater_than, count: 0
+
+    @ldap_config.alternative_port = 65536
+
+    assert @ldap_config.invalid?
+    assert_error @ldap_config, :alternative_port, :less_than, count: 65536
   end
 
   test 'validates that can connect' do
@@ -95,6 +121,25 @@ class LdapConfigTest < ActiveSupport::TestCase
     assert ldap.bind
   end
 
+  test 'ldap bind using full name with alternative ldap' do
+    assign_alternative_ldap
+
+    username = @ldap_config.login_mask % {
+      user:   'admin',
+      basedn: @ldap_config.basedn
+    }
+
+    ldap = @ldap_config.ldap username, 'admin123'
+
+    assert_raise Net::LDAP::Error do
+      ldap.bind
+    end
+
+    ldap = @ldap_config.alternative_ldap.ldap username, 'admin123'
+
+    assert ldap.bind
+  end
+
   test 'ldap no bind if wrong password' do
     ldap = @ldap_config.ldap 'admin', 'wrong'
 
@@ -112,6 +157,30 @@ class LdapConfigTest < ActiveSupport::TestCase
 
     assert user.organization_roles.map(&:role_id).exclude?(role.id)
     assert user.organization_roles.map(&:role_id).exclude?(corp_role.id)
+
+    assert_difference 'User.count' do
+      @ldap_config.import 'admin', 'admin123'
+    end
+
+    assert user.reload.organization_roles.map(&:role_id).include?(role.id)
+    assert user.organization_roles.map(&:role_id).include?(corp_role.id)
+    assert_equal user.id, User.find_by(user: 'new_user').manager_id
+    assert_nil user.manager_id
+  end
+
+  test 'import with alternative ldap' do
+    set_organization organizations(:google)
+
+    user      = users :administrator
+    role      = roles :admin_second_role
+    corp_role = roles :admin_second_alphabet_role
+
+    user.update! manager_id: users(:corporate).id
+
+    assert user.organization_roles.map(&:role_id).exclude?(role.id)
+    assert user.organization_roles.map(&:role_id).exclude?(corp_role.id)
+
+    assign_alternative_ldap
 
     assert_difference 'User.count' do
       @ldap_config.import 'admin', 'admin123'
@@ -237,4 +306,30 @@ class LdapConfigTest < ActiveSupport::TestCase
       @ldap_config.decrypted_password
     )
   end
+
+  test 'get alternative ldap only once' do
+    refute @ldap_config.try_alternative_ldap?
+
+    assign_alternative_ldap
+
+    assert @ldap_config.try_alternative_ldap?
+
+    old_config   = @ldap_config
+    @ldap_config = @ldap_config.alternative_ldap
+
+    refute @ldap_config.try_alternative_ldap?
+    refute old_config.try_alternative_ldap?
+
+    assert_nil @ldap_config.alternative_ldap
+  end
+
+  private
+
+    def assign_alternative_ldap
+      @ldap_config.update_columns(
+        hostname:             '0.0.0.1',
+        alternative_hostname: 'localhost',
+        alternative_port:     ldap_port
+      )
+    end
 end

--- a/test/models/ldap_config_test.rb
+++ b/test/models/ldap_config_test.rb
@@ -131,9 +131,7 @@ class LdapConfigTest < ActiveSupport::TestCase
 
     ldap = @ldap_config.ldap username, 'admin123'
 
-    assert_raise Net::LDAP::Error do
-      ldap.bind
-    end
+    assert_raise(Net::LDAP::Error) { ldap.bind }
 
     ldap = @ldap_config.alternative_ldap.ldap username, 'admin123'
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,6 +4,9 @@ require 'sidekiq/testing'
 
 Sidekiq::Testing.inline!
 
+Net::LDAP::Connection.send(:remove_const, 'DefaultConnectTimeout')
+Net::LDAP::Connection.const_set('DefaultConnectTimeout', 1)
+
 class ActiveSupport::TestCase
   set_fixture_class versions: PaperTrail::Version
   parallelize(workers: 1)
@@ -90,5 +93,9 @@ class ActiveSupport::TestCase
         job_class.perform_now(mailer, mail_method, delivery_method, args: new_args)
       end
     end
+  end
+
+  def ldap_port
+    ENV['TRAVIS'] ? 3389 : 389
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,8 +4,8 @@ require 'sidekiq/testing'
 
 Sidekiq::Testing.inline!
 
-Net::LDAP::Connection.send(:remove_const, 'DefaultConnectTimeout')
-Net::LDAP::Connection.const_set('DefaultConnectTimeout', 1)
+Net::LDAP::Connection.send :remove_const, 'DefaultConnectTimeout'
+Net::LDAP::Connection::DefaultConnectTimeout = 1
 
 class ActiveSupport::TestCase
   set_fixture_class versions: PaperTrail::Version


### PR DESCRIPTION
Básicamente en los 2 lados que se usa ldap (login e import) fallbackeamos al secundario una vez que falle el principal.