### PR TITLE
Basic BestPractice search

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -37,6 +37,11 @@ class ApplicationController < ActionController::Base
   end
   helper_method :can_perform?
 
+  def search_params
+    @search_params ||= params[:search]&.permit(:query, columns: []).to_h.symbolize_keys
+  end
+  helper_method :search_params
+
   private
 
     def scope_current_organization

--- a/app/controllers/best_practices_controller.rb
+++ b/app/controllers/best_practices_controller.rb
@@ -9,7 +9,7 @@ class BestPracticesController < ApplicationController
 
   # * GET /best_practices
   def index
-    @best_practices = BestPractice.list.search(**search_params).page(params[:page])
+    @best_practices = BestPractice.list.search(**search_params).ordered.page(params[:page])
   end
 
   # * GET /best_practices/1

--- a/app/controllers/best_practices_controller.rb
+++ b/app/controllers/best_practices_controller.rb
@@ -9,11 +9,7 @@ class BestPracticesController < ApplicationController
 
   # * GET /best_practices
   def index
-    build_search_conditions BestPractice
-
-    @best_practices = BestPractice.list.where(@conditions).reorder(
-      obsolete: :asc, name: :asc
-    ).page(params[:page])
+    @best_practices = BestPractice.list.search(**search_params).page(params[:page])
   end
 
   # * GET /best_practices/1

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -150,9 +150,11 @@ module ApplicationHelper
     raise 'Must have at least one column' if columns.empty?
 
     html_classes = ['filterable']
-    content = content_tag(:span, title, :class => :title)
-    selected = @query.blank? || columns.any? { |c| @columns.include?(c) }
-    options ||= {}
+    content      = content_tag(:span, title, :class => :title)
+    options      ||= {}
+    selected     = search_params[:query].blank? || columns.any? do |c|
+      (search_params[:columns] || @columns).include? c
+    end
 
     html_classes << 'selected' if selected
     html_classes << options[:class] if options[:class]
@@ -170,7 +172,7 @@ module ApplicationHelper
   def make_not_available_column(title, options = {})
     html_classes = []
 
-    html_classes << 'not-available' unless @query.blank? && @order_by.blank?
+    html_classes << 'not-available' unless search_params[:query].blank? && @order_by.blank?
     html_classes << options[:class] if options[:class]
 
     content_tag(:th, title,

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -151,7 +151,7 @@ module ApplicationHelper
 
     html_classes = ['filterable']
     content      = content_tag(:span, title, :class => :title)
-    options      ||= {}
+    options    ||= {}
     selected     = search_params[:query].blank? || columns.any? do |c|
       (search_params[:columns] || @columns).include? c
     end

--- a/app/models/best_practice.rb
+++ b/app/models/best_practice.rb
@@ -6,6 +6,7 @@ class BestPractice < ApplicationRecord
   include BestPractices::DestroyValidation
   include BestPractices::Json
   include BestPractices::ProcessControls
+  include BestPractices::Scopes
   include BestPractices::Search
   include BestPractices::Shared
   include BestPractices::Validations

--- a/app/models/concerns/best_practices/scopes.rb
+++ b/app/models/concerns/best_practices/scopes.rb
@@ -1,0 +1,7 @@
+module BestPractices::Scopes
+  extend ActiveSupport::Concern
+
+  included do
+    scope :ordered, -> { order obsolete: :asc, name: :asc }
+  end
+end

--- a/app/models/concerns/best_practices/search.rb
+++ b/app/models/concerns/best_practices/search.rb
@@ -9,7 +9,7 @@ module BestPractices::Search
 
   module ClassMethods
     def search query: nil, columns: []
-      result = ordered
+      result = all
 
       if query.present?
         columns.each do |column|

--- a/app/models/concerns/best_practices/search.rb
+++ b/app/models/concerns/best_practices/search.rb
@@ -3,25 +3,23 @@ module BestPractices::Search
 
   included do
     COLUMNS_FOR_SEARCH = {
-      name: name_options
+      name: "#{quoted_table_name}.#{qcn 'name'}".freeze
     }.with_indifferent_access
   end
 
   module ClassMethods
-    private
+    def search query: nil, columns: []
+      result = ordered
 
-      def name_options
-        string_column_options_for "#{quoted_table_name}.#{qcn 'name'}"
+      if query.present?
+        columns.each do |column|
+          if (quoted_column = COLUMNS_FOR_SEARCH[column])
+            result = result.where "#{quoted_column} ILIKE ?", "%#{query.strip}%"
+          end
+        end
       end
 
-      def string_column_options_for column
-        {
-          column:            "LOWER(#{column})",
-          operator:          'LIKE',
-          mask:              "%%%s%%",
-          conversion_method: :to_s,
-          regexp:            /.*/
-        }
-      end
+      result
+    end
   end
 end

--- a/app/models/concerns/best_practices/search.rb
+++ b/app/models/concerns/best_practices/search.rb
@@ -14,7 +14,7 @@ module BestPractices::Search
       if query.present?
         columns.each do |column|
           if (quoted_column = COLUMNS_FOR_SEARCH[column])
-            result = result.where "#{quoted_column} ILIKE ?", "%#{query.strip}%"
+            result = result.where "LOWER(#{quoted_column}) LIKE ?", "%#{query.strip.downcase}%"
           end
         end
       end

--- a/app/views/best_practices/index.html.erb
+++ b/app/views/best_practices/index.html.erb
@@ -1,6 +1,6 @@
 <%= render partial: 'shared/search', locals: {
   options: {},
-  columns: @query.blank? ? BestPractice::COLUMNS_FOR_SEARCH.keys : @columns
+  columns: search_params[:columns] || BestPractice::COLUMNS_FOR_SEARCH.keys
 } %>
 <table class="table table-sm table-striped table-hover">
   <thead id="column_headers">

--- a/app/views/shared/_search.html.erb
+++ b/app/views/shared/_search.html.erb
@@ -1,9 +1,9 @@
 <% url = options[:url] || url_for(:action => :index) %>
 <% extra_parameters = options[:extra_parameters] || [] %>
 <% columns_for_sort = options[:columns_for_sort] || [] %>
-<% query_string = params[:search] ? params[:search][:query] : nil %>
+<% query_string = search_params[:query] %>
 <% order_field = params[:search] ? params[:search][:order] : nil %>
-<div id="search" <%== "style='display: none;'" if (@query.blank? && @order_by.blank?) %>>
+<div id="search" <%== "style='display: none;'" if (query_string.blank? && @order_by.blank?) %>>
   <%= simple_form_for url, html: { method: :get, data: { no_observe_changes: true } } do |f| %>
     <div class="row">
       <div class="<%= columns_for_sort.empty? ? 'col-7 col-md-10' : 'col-5 col-md-7' %>">
@@ -40,7 +40,7 @@
     <% end %>
   <% end %>
 </div>
-<% unless @query.blank? && @order_by.blank? %>
+<% unless query_string.blank? && @order_by.blank? %>
   <% content_for :js_extra_bottom do %>
     $('search_query').focus();
     Search.observe();


### PR DESCRIPTION
No se si la idea sería así bien básico, o sería agregar toda la **logicota** que ayuda con los operadores `y`, `>=`, etc...

El `query_params` de momento no considera orden ya que no quise _extender_  el PR (ya que la BP no lo usan).

En la parte de buenas prácticas solo se busca por nombre, le deje la lógica que si hace click en Nombre y busca algo, es como si no buscase nada jaja, (supongo que para cuando tenga mas columnas).