### PR TITLE
MS-20-ImplementGithubActionsForCI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,30 +69,54 @@ jobs:
             || contains(github.ref_name, 'hipotecario')
             || contains(github.ref_name, 'naranja')
             || contains(github.ref_name, 'nbch')
-            || contains(github.ref_name, 'petersen') }}
+            || contains(github.ref_name, 'petersen')
+            || contains(github.event.pull_request.base.ref, 'master')
+            || contains(github.event.pull_request.base.ref, 'bancotdf')
+            || endsWith(github.event.pull_request.base.ref, 'bi')
+            || contains(github.event.pull_request.base.ref, 'bica')
+            || contains(github.event.pull_request.base.ref, 'bice')
+            || contains(github.event.pull_request.base.ref, 'bvalores')
+            || contains(github.event.pull_request.base.ref, 'galicia')
+            || contains(github.event.pull_request.base.ref, 'hipotecario')
+            || contains(github.event.pull_request.base.ref, 'naranja')
+            || contains(github.event.pull_request.base.ref, 'nbch')
+            || contains(github.event.pull_request.base.ref, 'petersen') }}
         use_v27:
           - >-
             ${{ contains(github.ref_name, 'master')
             || contains(github.ref_name, 'bna')
             || contains(github.ref_name, 'dino')
-            || contains(github.ref_name, 'patagonia') }}
+            || contains(github.ref_name, 'patagonia')
+            || contains(github.event.pull_request.base.ref, 'master')
+            || contains(github.event.pull_request.base.ref, 'bna')
+            || contains(github.event.pull_request.base.ref, 'dino')
+            || contains(github.event.pull_request.base.ref, 'patagonia') }}
         use_bh:
           - >-
             ${{ contains(github.ref_name, 'master')
-            || contains(github.ref_name, 'hipotecario') }}
+            || contains(github.ref_name, 'hipotecario')
+            || contains(github.event.pull_request.base.ref, 'master')
+            || contains(github.event.pull_request.base.ref, 'hipotecario') }}
         use_bic:
           - >-
             ${{ contains(github.ref_name, 'master')
-            || contains(github.ref_name, 'bice') }}
+            || contains(github.ref_name, 'bice')
+            || contains(github.event.pull_request.base.ref, 'master')
+            || contains(github.event.pull_request.base.ref, 'bice') }}
         use_cycle_score:
           - >-
             ${{ contains(github.ref_name, 'master')
-            || contains(github.ref_name, 'patagonia') }}
+            || contains(github.ref_name, 'patagonia')
+            || contains(github.event.pull_request.base.ref, 'master')
+            || contains(github.event.pull_request.base.ref, 'patagonia') }}
         use_gal:
           - >-
             ${{ contains(github.ref_name, 'master')
             || contains(github.ref_name, 'galicia')
-            || contains(github.ref_name, 'naranja') }}
+            || contains(github.ref_name, 'naranja')
+            || contains(github.event.pull_request.base.ref, 'master')
+            || contains(github.event.pull_request.base.ref, 'galicia')
+            || contains(github.event.pull_request.base.ref, 'naranja') }}
         use_normal:
           - >-
             ${{ contains(github.ref_name, 'master')
@@ -103,9 +127,20 @@ jobs:
             || contains(github.ref_name, 'nbch')
             || contains(github.ref_name, 'petersen')
             || contains(github.ref_name, 'bna')
-            || contains(github.ref_name, 'dino') }}
+            || contains(github.ref_name, 'dino')
+            || contains(github.event.pull_request.base.ref, 'master')
+            || contains(github.event.pull_request.base.ref, 'bancotdf')
+            || endsWith(github.event.pull_request.base.ref, 'bi')
+            || contains(github.event.pull_request.base.ref, 'bica')
+            || contains(github.event.pull_request.base.ref, 'bvalores')
+            || contains(github.event.pull_request.base.ref, 'nbch')
+            || contains(github.event.pull_request.base.ref, 'petersen')
+            || contains(github.event.pull_request.base.ref, 'bna')
+            || contains(github.event.pull_request.base.ref, 'dino') }}
         use_reviews_scored_by_weakness:
-          - ${{ contains(github.ref_name, 'master') }}
+          - >-
+            ${{ contains(github.ref_name, 'master')
+            || contains(github.event.pull_request.base.ref, 'master') }}
         exclude:
           - use_v26: false
             ruby-version: 2.6

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,173 @@
+name: CI
+on:
+  push:
+    branches:
+      - master
+      - c-bancotdf
+      - c-bi
+      - c-bica
+      - c-bice-production
+      - c-bna-aud
+      - c-bna-pla
+      - c-bvalores
+      - c-bvalores-test
+      - c-dino-production
+      - c-galicia-production
+      - c-galicia-test
+      - c-hipotecario
+      - c-naranja
+      - c-nbch
+      - c-patagonia-production
+      - c-patagonia-test
+      - c-petersen-production
+      - c-petersen-test
+  pull_request:
+    branches:
+      - master
+      - c-bancotdf
+      - c-bi
+      - c-bica
+      - c-bice-production
+      - c-bna-aud
+      - c-bna-pla
+      - c-bvalores
+      - c-bvalores-test
+      - c-dino-production
+      - c-galicia-production
+      - c-galicia-test
+      - c-hipotecario
+      - c-naranja
+      - c-nbch
+      - c-patagonia-production
+      - c-patagonia-test
+      - c-petersen-production
+      - c-petersen-test
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version:
+          - 2.6
+          - 2.7
+        config-type:
+          - normal
+          - gal
+          - bic
+          - bh
+          - cycle_score
+          - reviews_scored_by_weakness
+        use_v26:
+          - >-
+            ${{ contains(github.ref_name, 'master')
+            || contains(github.ref_name, 'bancotdf')
+            || endsWith(github.ref_name, 'bi')
+            || contains(github.ref_name, 'bica')
+            || contains(github.ref_name, 'bice')
+            || contains(github.ref_name, 'bvalores')
+            || contains(github.ref_name, 'galicia')
+            || contains(github.ref_name, 'hipotecario')
+            || contains(github.ref_name, 'naranja')
+            || contains(github.ref_name, 'nbch')
+            || contains(github.ref_name, 'petersen') }}
+        use_v27:
+          - >-
+            ${{ contains(github.ref_name, 'master')
+            || contains(github.ref_name, 'bna')
+            || contains(github.ref_name, 'dino')
+            || contains(github.ref_name, 'patagonia') }}
+        use_bh:
+          - >-
+            ${{ contains(github.ref_name, 'master')
+            || contains(github.ref_name, 'hipotecario') }}
+        use_bic:
+          - >-
+            ${{ contains(github.ref_name, 'master')
+            || contains(github.ref_name, 'bice') }}
+        use_cycle_score:
+          - >-
+            ${{ contains(github.ref_name, 'master')
+            || contains(github.ref_name, 'patagonia') }}
+        use_gal:
+          - >-
+            ${{ contains(github.ref_name, 'master')
+            || contains(github.ref_name, 'galicia')
+            || contains(github.ref_name, 'naranja') }}
+        use_normal:
+          - >-
+            ${{ contains(github.ref_name, 'master')
+            || contains(github.ref_name, 'bancotdf')
+            || endsWith(github.ref_name, 'bi')
+            || contains(github.ref_name, 'bica')
+            || contains(github.ref_name, 'bvalores')
+            || contains(github.ref_name, 'nbch')
+            || contains(github.ref_name, 'petersen')
+            || contains(github.ref_name, 'bna')
+            || contains(github.ref_name, 'dino') }}
+        use_reviews_scored_by_weakness:
+          - ${{ contains(github.ref_name, 'master') }}
+        exclude:
+          - use_v26: false
+            ruby-version: 2.6
+          - use_v27: false
+            ruby-version: 2.7
+          - use_bh: false
+            config-type: bh
+          - use_normal: false
+            config-type: normal
+          - use_gal: false
+            config-type: gal
+          - use_bic: false
+            config-type: bic
+          - use_cycle_score: false
+            config-type: cycle_score
+          - use_reviews_scored_by_weakness: false
+            config-type: reviews_scored_by_weakness
+    services:
+      postgres:
+        image: postgres:13
+        ports:
+          - '5432:5432'
+        env:
+          POSTGRES_DB: mawidabp_test
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      redis:
+        image: redis
+        ports:
+          - '6379:6379'
+        options: --entrypoint redis-server
+    env:
+      RAILS_ENV: test
+      GH_ACTIONS: true
+      DATABASE_URL: "postgres://postgres:postgres@localhost:5432/mawidabp_test"
+      REDIS_URL: redis://localhost:6379/0
+      RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
+      SECRET_KEY_BASE: ${{ secrets.SECRET_KEY_BASE }}
+      APP_HOST: 'lvh.me'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Install sldap
+        run: sudo apt -y install slapd ldap-utils
+      - name: Install ruby and gems
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true
+      - name: Migrate database
+        run: bin/rails db:migrate
+      - name: Copy application.yml
+        run: cp config/application.${{ matrix.config-type }}.yml config/application.yml
+      - name: Set up and run slpad
+        run: |
+          sudo cp test/fixtures/ldap/slapd.conf /etc/ldap/
+          sudo slapd -f /etc/ldap/slapd.conf -h ldap://localhost:3389
+          bundle exec rails ldap:reset
+      - name: Run tests
+        run: bin/rails test

--- a/README.md
+++ b/README.md
@@ -2,4 +2,24 @@
 
 Audit assistant web application
 
-[![Build Status](https://travis-ci.org/cirope/mawidabp.svg?branch=master)](https://travis-ci.org/cirope/mawidabp)
+Workflow status badge by branch:
+
+- `master`: [![CI](https://github.com/cirope/mawidabp/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/cirope/mawidabp/actions/workflows/main.yml)
+- `c-bancotdf`: [![CI](https://github.com/cirope/mawidabp/actions/workflows/main.yml/badge.svg?branch=c-bancotdf)](https://github.com/cirope/mawidabp/actions/workflows/main.yml)
+- `c-bi`: [![CI](https://github.com/cirope/mawidabp/actions/workflows/main.yml/badge.svg?branch=c-bi)](https://github.com/cirope/mawidabp/actions/workflows/main.yml)
+- `c-bica`: [![CI](https://github.com/cirope/mawidabp/actions/workflows/main.yml/badge.svg?branch=c-bica)](https://github.com/cirope/mawidabp/actions/workflows/main.yml)
+- `c-bice-production`: [![CI](https://github.com/cirope/mawidabp/actions/workflows/main.yml/badge.svg?branch=c-bice-production)](https://github.com/cirope/mawidabp/actions/workflows/main.yml)
+- `c-bna-aud`: [![CI](https://github.com/cirope/mawidabp/actions/workflows/main.yml/badge.svg?branch=c-bna-aud)](https://github.com/cirope/mawidabp/actions/workflows/main.yml)
+- `c-bna-pla`: [![CI](https://github.com/cirope/mawidabp/actions/workflows/main.yml/badge.svg?branch=c-bna-pla)](https://github.com/cirope/mawidabp/actions/workflows/main.yml)
+- `c-bvalores`: [![CI](https://github.com/cirope/mawidabp/actions/workflows/main.yml/badge.svg?branch=c-bvalores)](https://github.com/cirope/mawidabp/actions/workflows/main.yml)
+- `c-bvalores-test`: [![CI](https://github.com/cirope/mawidabp/actions/workflows/main.yml/badge.svg?branch=c-bvalores-test)](https://github.com/cirope/mawidabp/actions/workflows/main.yml)
+- `c-dino-production`: [![CI](https://github.com/cirope/mawidabp/actions/workflows/main.yml/badge.svg?branch=c-dino-production)](https://github.com/cirope/mawidabp/actions/workflows/main.yml)
+- `c-galicia-production`: [![CI](https://github.com/cirope/mawidabp/actions/workflows/main.yml/badge.svg?branch=c-galicia-production)](https://github.com/cirope/mawidabp/actions/workflows/main.yml)
+- `c-galicia-test`: [![CI](https://github.com/cirope/mawidabp/actions/workflows/main.yml/badge.svg?branch=c-galicia-test)](https://github.com/cirope/mawidabp/actions/workflows/main.yml)
+- `c-hipotecario`: [![CI](https://github.com/cirope/mawidabp/actions/workflows/main.yml/badge.svg?branch=c-hipotecario)](https://github.com/cirope/mawidabp/actions/workflows/main.yml)
+- `c-naranja`: [![CI](https://github.com/cirope/mawidabp/actions/workflows/main.yml/badge.svg?branch=c-naranja)](https://github.com/cirope/mawidabp/actions/workflows/main.yml)
+- `c-nbch`: [![CI](https://github.com/cirope/mawidabp/actions/workflows/main.yml/badge.svg?branch=c-nbch)](https://github.com/cirope/mawidabp/actions/workflows/main.yml)
+- `c-patagonia-production`: [![CI](https://github.com/cirope/mawidabp/actions/workflows/main.yml/badge.svg?branch=c-patagonia-production)](https://github.com/cirope/mawidabp/actions/workflows/main.yml)
+- `c-patagonia-test`: [![CI](https://github.com/cirope/mawidabp/actions/workflows/main.yml/badge.svg?branch=c-patagonia-test)](https://github.com/cirope/mawidabp/actions/workflows/main.yml)
+- `c-petersen-production`: [![CI](https://github.com/cirope/mawidabp/actions/workflows/main.yml/badge.svg?branch=c-petersen-production)](https://github.com/cirope/mawidabp/actions/workflows/main.yml)
+- `c-petersen-test`: [![CI](https://github.com/cirope/mawidabp/actions/workflows/main.yml/badge.svg?branch=c-petersen-test)](https://github.com/cirope/mawidabp/actions/workflows/main.yml)

--- a/config/application.rb
+++ b/config/application.rb
@@ -27,7 +27,7 @@ module MawidaBP
 
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
     # Run "rake time:zones:all" for a time zone names list. Default is UTC.
-    config.time_zone = ENV['TRAVIS'] ? 'UTC' : 'Buenos Aires'
+    config.time_zone = ENV['GH_ACTIONS'] ? 'UTC' : 'Buenos Aires'
 
     # Be sure to have the adapter's gem in your Gemfile
     # and follow the adapter's specific installation

--- a/config/database.yml
+++ b/config/database.yml
@@ -4,9 +4,9 @@ default: &default
   host: <%= ENV['DB_HOST'] || 'localhost' %>
   port: 5432
   pool: 5
-  username: <%= ENV['TRAVIS'] ? 'postgres' : ENV['DB_USER'] || 'mawidabp' %>
-  password: <%= if ENV['TRAVIS']
-                  ''
+  username: <%= ENV['GH_ACTIONS'] ? 'postgres' : ENV['DB_USER'] || 'mawidabp' %>
+  password: <%= if ENV['GH_ACTIONS']
+                  'postgres'
                 elsif ENV['ENCRYPTED_DB_PASSWORD']
                   ActiveSupport::MessageEncryptor.new(
                     Rails.application.secrets.secret_key_base[0..31],

--- a/lib/tasks/ldap.rake
+++ b/lib/tasks/ldap.rake
@@ -2,7 +2,7 @@ namespace :ldap do
   desc 'Load LDAP users and groups'
   task :reset do
     ldap_root = File.expand_path '../../test/fixtures/ldap', File.dirname(__FILE__)
-    ldap_port = ENV['TRAVIS'] ? 3389 : 389
+    ldap_port = ENV['GH_ACTIONS'] ? 3389 : 389
     ldap_connect_string = "-x -c -h localhost -p #{ldap_port} -D 'cn=admin,dc=test,dc=com' -w secret"
 
     puts `ldapmodify #{ldap_connect_string} -f #{File.join(ldap_root, 'clear.ldif')}`

--- a/test/controllers/organizations_controller_test.rb
+++ b/test/controllers/organizations_controller_test.rb
@@ -95,7 +95,7 @@ class OrganizationsControllerTest < ActionController::TestCase
           group_id: groups(:main_group).id,
           ldap_config_attributes: {
             hostname: 'localhost',
-            port: ENV['TRAVIS'] ? 3389 : 389,
+            port: ENV['GH_ACTIONS'] ? 3389 : 389,
             basedn: 'ou=people,dc=test,dc=com',
             filter: 'CN=*',
             login_mask: 'cn=%{user},%{basedn}',

--- a/test/fixtures/ldap/slapd.conf
+++ b/test/fixtures/ldap/slapd.conf
@@ -16,8 +16,8 @@ allow bind_v2
 # service AND an understanding of referrals.
 #referral	ldap://root.openldap.org
 
-pidfile		test/fixtures/ldap/openldap-data/slapd.pid
-argsfile	test/fixtures/ldap/openldap-data/slapd.args
+pidfile   /run/slapd/slapd.pid
+argsfile  /run/slapd/slapd.args
 
 # Load dynamic backend modules:
 modulepath	/usr/lib/openldap
@@ -62,10 +62,10 @@ rootdn    "cn=admin,dc=test,dc=com"
 # Cleartext passwords, especially for the rootdn, should
 # be avoid.  See slappasswd(8) and slapd.conf(5) for details.
 # Use of strong authentication encouraged.
-# The database directory MUST exist prior to running slapd AND 
+# The database directory MUST exist prior to running slapd AND
 # should only be accessible by the slapd and slap tools.
 # Mode 700 recommended.
-directory	test/fixtures/ldap/openldap-data
+directory /etc/ldap/slapd.d
 # Indices to maintain
 # index	objectClass	eq
 rootpw    {SSHA}fFjKcZb4cfOAcwSjJer8nCGOEVRUnwCC

--- a/test/fixtures/ldap_configs.yml
+++ b/test/fixtures/ldap_configs.yml
@@ -1,6 +1,6 @@
 google_ldap:
   hostname: localhost
-  port: <%= ENV['TRAVIS'] ? 3389 : 389 %>
+  port: <%= ENV['GH_ACTIONS'] ? 3389 : 389 %>
   basedn: ou=people,dc=test,dc=com
   filter: 'CN=*'
   login_mask: "cn=%{user},%{basedn}"
@@ -18,7 +18,7 @@ google_ldap:
 
 alphabet_ldap:
   hostname: localhost
-  port: <%= ENV['TRAVIS'] ? 3389 : 389 %>
+  port: <%= ENV['GH_ACTIONS'] ? 3389 : 389 %>
   basedn: ou=people,dc=alphabet,dc=com
   filter: 'CN=*'
   login_mask: "cn=%{user},%{basedn}"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -107,6 +107,6 @@ class ActiveSupport::TestCase
   end
 
   def ldap_port
-    ENV['TRAVIS'] ? 3389 : 389
+    ENV['GH_ACTIONS'] ? 3389 : 389
   end
 end


### PR DESCRIPTION
#### Lógica utilizada

- Cuando se hace un `push`/`pull_request` a la rama `master` se ejecutan todos los tests en todas las combinaciones de versión-configuración posibles.
- Cuando se hace un `push`/`pull_request` a una rama de clientes (`c-*`) se ejecutan los tests en la versión y configuración particular de esa rama.

#### Omitir ejecuciones

Para evitar que se ejecuten los test podremos añadir cualquiera de los siguientes strings al mensaje del commit en un `push` o al HEAD commit de un `pull_request` ([+info](https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs))

- `[skip ci]`
- `[ci skip]`
- `[no ci]`
- `[skip actions]`
- `[actions skip]`

#### Omitir cancelación de jobs ante fallo

Por defecto, GitHub cancela todos los jobs en progreso en una matrix si uno falla ([+info](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast)). Para evitar esto podemos dehabilitar el `fail-fast`:

```
strategy:
  fail-fast: false
  matrix: ...
```

#### Posible refactoring

Las ramas que utilizamos para filtrar los eventos `push`/`pull_request` están listadas para facilitar la comparación con el apartado de exclusiones, aunque podríamos reducir ese código mediante el uso de [patrones](refactoring). Esto nos obliga a que el repositorio no contenga ramas no utilizadas que coincidan con ese patrón.

Del mismo modo, la matrix se podría generar en un job1 para luego ser utilizada en un job2 ([+info](https://docs.github.com/en/actions/learn-github-actions/expressions#example-returning-a-json-object)).