### PR TITLE
MS-126-AddPatFieldsToWeaknessTemplates

### DIFF
--- a/app/controllers/weakness_templates_controller.rb
+++ b/app/controllers/weakness_templates_controller.rb
@@ -59,8 +59,8 @@ class WeaknessTemplatesController < ApplicationController
     def weakness_template_params
       params.require(:weakness_template).permit(
         :reference, :title, :description, :risk, :allow_duplication,
-        :notes, :audit_recommendations, :lock_version,
-        :brief, :subreference, :failure,
+        :notes, :audit_recommendations, :brief, :subreference, :failure,
+        :lock_version,
         impact: [], operational_risk: [], internal_control_components: [],
         control_objective_weakness_template_relations_attributes: [
           :id, :control_objective_id, :_destroy

--- a/app/controllers/weakness_templates_controller.rb
+++ b/app/controllers/weakness_templates_controller.rb
@@ -60,6 +60,7 @@ class WeaknessTemplatesController < ApplicationController
       params.require(:weakness_template).permit(
         :reference, :title, :description, :risk, :allow_duplication,
         :notes, :audit_recommendations, :lock_version,
+        :brief, :subreference, :failure,
         impact: [], operational_risk: [], internal_control_components: [],
         control_objective_weakness_template_relations_attributes: [
           :id, :control_objective_id, :_destroy

--- a/app/models/concerns/findings/issues.rb
+++ b/app/models/concerns/findings/issues.rb
@@ -24,7 +24,7 @@ module Findings::Issues
   end
 
   def issues_percentage
-     impact_amount? ? issues.sum(&:amount) / impact_amount.to_f : 0
+    impact_amount? ? issues&.map(&:amount).compact.sum / impact_amount.to_f : 0
   end
 
   def get_amount_by_impact
@@ -146,7 +146,9 @@ module Findings::Issues
         all_closed  = valid_issues.all? &:close_date
         some_closed = valid_issues.any? &:close_date
 
-        if all_closed
+        if self.state == Finding::STATUS['failure']
+          self.follow_up_date = nil
+        elsif all_closed
           self.state         = Finding::STATUS['implemented_audited']
           self.solution_date = valid_issues.map(&:close_date).last
         elsif some_closed

--- a/app/views/weakness_templates/_form.html.erb
+++ b/app/views/weakness_templates/_form.html.erb
@@ -5,23 +5,27 @@
     <%= f.input :title, input_html: { autofocus: true } %>
 
     <div class="row">
-      <div class="col-md-4">
+      <div class="col-md-<%= USE_SCOPE_CYCLE ? 4 : 6 %>">
         <%= f.input :reference %>
       </div>
-      <div class="col-md-4">
-        <%= f.input :subreference %>
-      </div>
-      <div class="col-md-4">
+      <% if USE_SCOPE_CYCLE %>
+        <div class="col-md-4">
+          <%= f.input :subreference %>
+        </div>
+      <% end %>
+      <div class="col-md-<%= USE_SCOPE_CYCLE ? 4 : 6 %>">
         <%= f.input :risk, collection: risks, prompt: true %>
       </div>
     </div>
     <div class="row">
-      <div class="col-md-6">
+      <div class="col-md-<%= USE_SCOPE_CYCLE ? 6 : 12 %>">
         <%= f.input :description, input_html: { rows: 6 } %>
       </div>
-      <div class="col-md-6">
-        <%= f.input :brief, input_html: { rows: 6 } %>
-      </div>
+      <% if USE_SCOPE_CYCLE %>
+        <div class="col-md-6">
+          <%= f.input :brief, input_html: { rows: 6 } %>
+        </div>
+      <% end %>
     </div>
     <div class="row">
       <div class="col-md-6">
@@ -31,7 +35,9 @@
         <%= f.input :audit_recommendations, input_html: { rows: 6 } %>
       </div>
     </div>
-    <%= f.input :failure %>
+    <% if USE_SCOPE_CYCLE %>
+      <%= f.input :failure %>
+    <% end %>
     <% if SHOW_WEAKNESS_EXTRA_ATTRIBUTES %>
       <div class="row">
         <div class="col-md-4">

--- a/app/views/weakness_templates/_form.html.erb
+++ b/app/views/weakness_templates/_form.html.erb
@@ -5,14 +5,24 @@
     <%= f.input :title, input_html: { autofocus: true } %>
 
     <div class="row">
-      <div class="col-md-6">
+      <div class="col-md-4">
         <%= f.input :reference %>
       </div>
-      <div class="col-md-6">
+      <div class="col-md-4">
+        <%= f.input :subreference %>
+      </div>
+      <div class="col-md-4">
         <%= f.input :risk, collection: risks, prompt: true %>
       </div>
     </div>
-    <%= f.input :description, input_html: { rows: 6 } %>
+    <div class="row">
+      <div class="col-md-6">
+        <%= f.input :description, input_html: { rows: 6 } %>
+      </div>
+      <div class="col-md-6">
+        <%= f.input :brief, input_html: { rows: 6 } %>
+      </div>
+    </div>
     <div class="row">
       <div class="col-md-6">
         <%= f.input :notes, input_html: { rows: 6 } %>
@@ -21,6 +31,7 @@
         <%= f.input :audit_recommendations, input_html: { rows: 6 } %>
       </div>
     </div>
+    <%= f.input :failure %>
     <% if SHOW_WEAKNESS_EXTRA_ATTRIBUTES %>
       <div class="row">
         <div class="col-md-4">

--- a/app/views/weakness_templates/show.html.erb
+++ b/app/views/weakness_templates/show.html.erb
@@ -6,18 +6,22 @@
   <strong><%= WeaknessTemplate.human_attribute_name 'reference' %></strong>:
   <%= @weakness_template.reference %>
 </p>
-<p class="mb-1">
-  <strong><%= WeaknessTemplate.human_attribute_name 'subreference' %></strong>:
-  <%= @weakness_template.subreference %>
-</p>
+<% if USE_SCOPE_CYCLE %>
+  <p class="mb-1">
+    <strong><%= WeaknessTemplate.human_attribute_name 'subreference' %></strong>:
+    <%= @weakness_template.subreference %>
+  </p>
+<% end %>
 <p class="mb-1">
   <strong><%= WeaknessTemplate.human_attribute_name 'description' %></strong>:
   <%= simple_format @weakness_template.description, class: 'mb-1' %>
 </p>
-<p class="mb-1">
-  <strong><%= WeaknessTemplate.human_attribute_name 'brief' %></strong>:
-  <%= simple_format @weakness_template.brief, class: 'mb-1' %>
-</p>
+<% if USE_SCOPE_CYCLE %>
+  <p class="mb-1">
+    <strong><%= WeaknessTemplate.human_attribute_name 'brief' %></strong>:
+    <%= simple_format @weakness_template.brief, class: 'mb-1' %>
+  </p>
+<% end %>
 <p class="mb-1">
   <strong><%= WeaknessTemplate.human_attribute_name 'notes' %></strong>:
   <%= simple_format @weakness_template.notes, class: 'mb-1' %>
@@ -30,10 +34,12 @@
   <strong><%= WeaknessTemplate.human_attribute_name 'risk' %></strong>:
   <%= @weakness_template.risk_text %>
 </p>
-<p class="mb-1">
-  <strong><%= WeaknessTemplate.human_attribute_name 'failure' %></strong>:
-  <%= t @weakness_template.failure ? 'label.yes' : 'label.no' %>
-</p>
+<% if USE_SCOPE_CYCLE %>
+  <p class="mb-1">
+    <strong><%= WeaknessTemplate.human_attribute_name 'failure' %></strong>:
+    <%= t @weakness_template.failure ? 'label.yes' : 'label.no' %>
+  </p>
+<% end %>
 <% if SHOW_WEAKNESS_EXTRA_ATTRIBUTES %>
   <p class="mb-1">
     <strong><%= WeaknessTemplate.human_attribute_name 'impact' %></strong>:

--- a/app/views/weakness_templates/show.html.erb
+++ b/app/views/weakness_templates/show.html.erb
@@ -7,8 +7,16 @@
   <%= @weakness_template.reference %>
 </p>
 <p class="mb-1">
+  <strong><%= WeaknessTemplate.human_attribute_name 'subreference' %></strong>:
+  <%= @weakness_template.subreference %>
+</p>
+<p class="mb-1">
   <strong><%= WeaknessTemplate.human_attribute_name 'description' %></strong>:
   <%= simple_format @weakness_template.description, class: 'mb-1' %>
+</p>
+<p class="mb-1">
+  <strong><%= WeaknessTemplate.human_attribute_name 'brief' %></strong>:
+  <%= simple_format @weakness_template.brief, class: 'mb-1' %>
 </p>
 <p class="mb-1">
   <strong><%= WeaknessTemplate.human_attribute_name 'notes' %></strong>:
@@ -21,6 +29,10 @@
 <p class="mb-1">
   <strong><%= WeaknessTemplate.human_attribute_name 'risk' %></strong>:
   <%= @weakness_template.risk_text %>
+</p>
+<p class="mb-1">
+  <strong><%= WeaknessTemplate.human_attribute_name 'failure' %></strong>:
+  <%= t @weakness_template.failure ? 'label.yes' : 'label.no' %>
 </p>
 <% if SHOW_WEAKNESS_EXTRA_ATTRIBUTES %>
   <p class="mb-1">

--- a/app/views/weaknesses/weakness_template_changed.js.erb
+++ b/app/views/weaknesses/weakness_template_changed.js.erb
@@ -10,6 +10,10 @@ $('[id^=weakness_internal_control_components]').prop('checked', false).trigger('
   $('[name$="[risk]"]').val('<%= @weakness_template.risk %>')
   $('[name$="[audit_recommendations]"]').val('<%= j @weakness_template.audit_recommendations %>')
 
+  <% if @weakness_template.failure %>
+    $('[name$="[state]"]').val('<%= j Finding::STATUS['failure'] %>')
+  <% end %>
+
   <% Array(@weakness_template.impact).each do |value| %>
     $('[id^=weakness_impact][value="<%= j value %>"]').prop('checked', true).trigger('custom:change')
   <% end %>

--- a/app/views/weaknesses/weakness_template_changed.js.erb
+++ b/app/views/weaknesses/weakness_template_changed.js.erb
@@ -6,7 +6,7 @@ $('[id^=weakness_internal_control_components]').prop('checked', false).trigger('
   $('[name$="[title]"]').val('<%= j @weakness_template.title %>')
   $('[name$="[description]"]').val('<%= j @weakness_template.description %>')
   $('[data-notes]').text('<%= j @weakness_template.notes %>')
-  $('[name$="[brief]"]').val('<%= j @weakness_template.description %>')
+  $('[name$="[brief]"]').val('<%= j @weakness_template.brief %>')
   $('[name$="[risk]"]').val('<%= @weakness_template.risk %>')
   $('[name$="[audit_recommendations]"]').val('<%= j @weakness_template.audit_recommendations %>')
 

--- a/config/locales/models.es.yml
+++ b/config/locales/models.es.yml
@@ -749,8 +749,10 @@ es:
         image: 'Imagen'
       weakness_template:
         reference: 'Referencia'
+        subreference: 'Subreferencia'
         title: 'Título'
         description: 'Observación'
+        brief: 'Resumen'
         risk: 'Riesgo'
         operational_risk: 'Riesgo operacional'
         impact: 'Impacto'
@@ -758,6 +760,7 @@ es:
         internal_control_components: 'Componentes de CI'
         allow_duplication: 'Permitir título duplicado'
         audit_recommendations: 'Recomendaciones de auditoría'
+        failure: 'Falla'
 
     errors:
       models:

--- a/db/migrate/20220425214624_add_pat_fields_to_weakness_templates.rb
+++ b/db/migrate/20220425214624_add_pat_fields_to_weakness_templates.rb
@@ -1,0 +1,7 @@
+class AddPatFieldsToWeaknessTemplates < ActiveRecord::Migration[6.1]
+  def change
+    add_column :weakness_templates, :brief, :text
+    add_column :weakness_templates, :subreference, :string
+    add_column :weakness_templates, :failure, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_20_144217) do
+ActiveRecord::Schema.define(version: 2022_04_25_214624) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
@@ -1274,6 +1274,9 @@ ActiveRecord::Schema.define(version: 2022_04_20_144217) do
     t.string "reference"
     t.text "notes"
     t.text "audit_recommendations"
+    t.text "brief"
+    t.string "subreference"
+    t.boolean "failure", default: false, null: false
     t.index ["organization_id"], name: "index_weakness_templates_on_organization_id"
     t.index ["reference"], name: "index_weakness_templates_on_reference"
   end

--- a/test/controllers/weakness_templates_controller_test.rb
+++ b/test/controllers/weakness_templates_controller_test.rb
@@ -40,8 +40,11 @@ class WeaknessTemplatesControllerTest < ActionController::TestCase
     assert_difference counts do
       post :create, params: {
         weakness_template: {
+          referece: '321',
+          subreference: '654',
           title: 'New weakness template',
           description: 'New weakness template description',
+          brief: 'New weakness template brief',
           risk: WeaknessTemplate.risks_values.first,
           operational_risk: ['internal fraud'],
           impact: ['econimic', 'regulatory'],
@@ -51,7 +54,8 @@ class WeaknessTemplatesControllerTest < ActionController::TestCase
               control_objective_id: control_objectives(:impact_analysis).id
             }
           ],
-          audit_recommendations: 'test'
+          audit_recommendations: 'test',
+          failure: true
         }
       }
     end

--- a/test/fixtures/weakness_templates.yml
+++ b/test/fixtures/weakness_templates.yml
@@ -1,9 +1,12 @@
 security:
   reference: '123'
+  subreference: '456'
   title: Security weakness
   description: Some nasty security bug
+  brief: A brief of the security bug
   risk: <%= Finding.risks_values.last %>
   impact: ['econimic', 'regulatory']
   operational_risk: ['internal fraud']
   internal_control_components: ['risk_evaluation', 'monitoring']
   organization: cirope
+  failure: false


### PR DESCRIPTION
Agrega 3 campos a `weakness_templates`:

- `brief` text
- `subreference` string
- `failure` boolean

El campo `brief` se utiliza para autocompletar el campo con el mismo nombre de `weakness`

Se utiliza la variable de entorno `USE_SCOPE_CYCLE` para condicionar la visibilidad de los campos en la vista