### PR TITLE
MS-133_Fix_html_reserved_character_error_in_pdf

### DIFF
--- a/app/models/concerns/findings/weakness_report_pdf.rb
+++ b/app/models/concerns/findings/weakness_report_pdf.rb
@@ -172,7 +172,7 @@ module Findings::WeaknessReportPdf
 
       labels.each do |filter_name, filter_label|
         if report_params[filter_name].present?
-          operator = report_params["#{filter_name}_operator"] || '='
+          operator = report_params["#{filter_name}_operator"]&.sub('<', '&lt;') || '='
           value = if value_filter_names.include? filter_name
                     weaknesses_report_value_to_label report_params, filter_name
                   elsif operator == 'between'


### PR DESCRIPTION
Al aplicar un aplicar un `inline_format: true` al texto que se agrega al pdf en el método [add_pdf_filters](https://github.com/cirope/mawidabp/blob/119ef10ded0a92cece07b5291ca8f382bd76e923/app/concerns/reports/base_pdf.rb#L42), el caracter `<` era omitido por ser reservado de html.

Se agregó el reemplazo de `<` por `&lt;` para evitar ese conflicto

Captura:
![image](https://user-images.githubusercontent.com/36643035/167769397-0569831b-daba-4fd2-9623-73dbac4a81d1.png)


