### PR TITLE
MS-305_GAL_Allows_the_executive_summary_introduction_to_be_dynamic

### DIFF
--- a/app/controllers/business_unit_types_controller.rb
+++ b/app/controllers/business_unit_types_controller.rb
@@ -110,8 +110,8 @@ class BusinessUnitTypesController < ApplicationController
       params.require(:business_unit_type).permit(
         :name, :business_unit_label, :project_label, :review_prefix, :sectors,
         :recipients, :external, :require_tag, :require_counts,
-        :hide_review_logo, :independent_identification, :shared_business_units,
-        :without_number, :reviews_for, :detailed_review,
+        :hide_review_logo, :exec_summary_intro, :independent_identification,
+        :shared_business_units, :without_number, :reviews_for, :detailed_review,
         :grouped_by_business_unit_annual_report, :lock_version,
         business_units_attributes: [:id, :name, :business_unit_kind_id, :_destroy]
       )

--- a/app/models/concerns/business_unit_types/validations.rb
+++ b/app/models/concerns/business_unit_types/validations.rb
@@ -22,14 +22,16 @@ module BusinessUnitTypes::Validations
     end
 
     def exec_summary_intro_must_have_valid_keys
-      review_key   = I18n.t "conclusion_review.executive_summary.keywords.review"
-      valid_keys   = [review_key]
-      field_keys   = exec_summary_intro.scan(/%\{(.*?)\}/).flatten
-      missing_keys = field_keys - valid_keys
+      if exec_summary_intro
+        review_key   = I18n.t "conclusion_review.executive_summary.keywords.review"
+        valid_keys   = [review_key]
+        field_keys   = exec_summary_intro.scan(/%\{(.*?)\}/).flatten
+        missing_keys = field_keys - valid_keys
 
-      if missing_keys.any?
-        errors.add :exec_summary_intro, :missing_keys, count: missing_keys.count,
-          invalid_keys: missing_keys.to_sentence
+        if missing_keys.any?
+          errors.add :exec_summary_intro, :missing_keys, count: missing_keys.count,
+            invalid_keys: missing_keys.to_sentence
+        end
       end
     end
 

--- a/app/models/concerns/business_unit_types/validations.rb
+++ b/app/models/concerns/business_unit_types/validations.rb
@@ -22,13 +22,14 @@ module BusinessUnitTypes::Validations
     end
 
     def exec_summary_intro_must_have_valid_keys
+      review_key   = I18n.t "conclusion_review.executive_summary.keywords.review"
+      valid_keys   = [review_key]
       field_keys   = exec_summary_intro.scan(/%\{(.*?)\}/).flatten
-      valid_keys   = ['informe']
       missing_keys = field_keys - valid_keys
 
       if missing_keys.any?
         errors.add :exec_summary_intro, :missing_keys, count: missing_keys.count,
-          valid_keys: valid_keys.to_sentence, invalid_keys: missing_keys.to_sentence
+          invalid_keys: missing_keys.to_sentence
       end
     end
 

--- a/app/models/concerns/business_unit_types/validations.rb
+++ b/app/models/concerns/business_unit_types/validations.rb
@@ -12,9 +12,25 @@ module BusinessUnitTypes::Validations
       case_sensitive: false, scope: :organization_id
     }
     validate :all_units_marked_for_destruction_can_be_destroyed
+    validate :exec_summary_intro_must_have_valid_keys, if: :is_gal?
   end
 
   private
+
+    def is_gal?
+      Current.conclusion_pdf_format == 'gal'
+    end
+
+    def exec_summary_intro_must_have_valid_keys
+      field_keys   = exec_summary_intro.scan(/%\{(.*?)\}/).flatten
+      valid_keys   = ['informe']
+      missing_keys = field_keys - valid_keys
+
+      if missing_keys.any?
+        errors.add :exec_summary_intro, :missing_keys, count: missing_keys.count,
+          valid_keys: valid_keys.to_sentence, invalid_keys: missing_keys.to_sentence
+      end
+    end
 
     def all_units_marked_for_destruction_can_be_destroyed
       locked = business_units.any? do |bu|

--- a/app/models/concerns/conclusion_reviews/gal_pdf.rb
+++ b/app/models/concerns/conclusion_reviews/gal_pdf.rb
@@ -66,15 +66,19 @@ module ConclusionReviews::GalPdf
     end
 
     def put_executive_summary_on pdf, organization
-      title              = I18n.t 'conclusion_review.executive_summary.title'
-      exec_summary_intro = review.business_unit_type.exec_summary_intro
-      project            = review.plan_item.project
-      params             = { informe: review.identification }
+      title                      = I18n.t 'conclusion_review.executive_summary.title'
+      review_key                 = I18n.t "conclusion_review.executive_summary.keywords.review"
+      params                     = { "#{review_key}": review.identification }
+      exec_summary_intro         = review.business_unit_type.exec_summary_intro
+      independent_identification = review.business_unit_type.independent_identification
+      project                    = review.plan_item.project
 
       full_exec_summary_intro = if exec_summary_intro
                                   exec_summary_intro % params
+                                elsif independent_identification
+                                  I18n.t "conclusion_review.executive_summary.intro_alt"
                                 else
-                                  I18n.t "conclusion_review.executive_summary.project"
+                                  I18n.t "conclusion_review.executive_summary.intro_default"
                                 end
 
       pdf.start_new_page

--- a/app/models/concerns/conclusion_reviews/gal_pdf.rb
+++ b/app/models/concerns/conclusion_reviews/gal_pdf.rb
@@ -85,7 +85,7 @@ module ConclusionReviews::GalPdf
       pdf.add_title title, (PDF_FONT_SIZE * 2).round, :center
       pdf.move_down PDF_FONT_SIZE * 2
 
-      pdf.text "#{full_exec_summary_intro} <b>#{project}</b>", inline_format: true
+      pdf.text "#{full_exec_summary_intro} <b>#{project}</b>", align: :justify, inline_format: true
 
       put_risk_exposure_on pdf
       put_gal_score_on     pdf

--- a/app/models/concerns/conclusion_reviews/gal_pdf.rb
+++ b/app/models/concerns/conclusion_reviews/gal_pdf.rb
@@ -66,17 +66,22 @@ module ConclusionReviews::GalPdf
     end
 
     def put_executive_summary_on pdf, organization
-      title           = I18n.t 'conclusion_review.executive_summary.title'
-      use_alt_project = review.business_unit_type.independent_identification
-      project_label   = use_alt_project ? 'project_alt' : 'project'
-      project_title   = I18n.t "conclusion_review.executive_summary.#{project_label}"
-      project         = review.plan_item.project
+      title              = I18n.t 'conclusion_review.executive_summary.title'
+      exec_summary_intro = review.business_unit_type.exec_summary_intro
+      project            = review.plan_item.project
+      params             = { informe: review.identification }
+
+      full_exec_summary_intro = if exec_summary_intro
+                                  exec_summary_intro % params
+                                else
+                                  I18n.t "conclusion_review.executive_summary.project"
+                                end
 
       pdf.start_new_page
       pdf.add_title title, (PDF_FONT_SIZE * 2).round, :center
       pdf.move_down PDF_FONT_SIZE * 2
 
-      pdf.text "#{project_title} <b>#{project}</b>", inline_format: true
+      pdf.text "#{full_exec_summary_intro} <b>#{project}</b>", inline_format: true
 
       put_risk_exposure_on pdf
       put_gal_score_on     pdf

--- a/app/models/concerns/conclusion_reviews/gal_pdf.rb
+++ b/app/models/concerns/conclusion_reviews/gal_pdf.rb
@@ -73,7 +73,7 @@ module ConclusionReviews::GalPdf
       independent_identification = review.business_unit_type.independent_identification
       project                    = review.plan_item.project
 
-      full_exec_summary_intro = if exec_summary_intro
+      full_exec_summary_intro = if exec_summary_intro.present?
                                   exec_summary_intro % params
                                 elsif independent_identification
                                   I18n.t "conclusion_review.executive_summary.intro_alt"

--- a/app/views/business_unit_types/_form.html.erb
+++ b/app/views/business_unit_types/_form.html.erb
@@ -60,6 +60,9 @@
 
     <% if Current.conclusion_pdf_format == 'gal' %>
       <div class="row">
+        <div class="col-md-6">
+          <%= f.input :exec_summary_intro, input_html: { rows: 4 } %>
+        </div>
         <div class="col-md-3">
           <%= f.input :independent_identification %>
         </div>

--- a/app/views/business_unit_types/_form.html.erb
+++ b/app/views/business_unit_types/_form.html.erb
@@ -61,7 +61,10 @@
     <% if Current.conclusion_pdf_format == 'gal' %>
       <div class="row">
         <div class="col-md-6">
-          <%= f.input :exec_summary_intro, input_html: { rows: 4 } %>
+          <%= f.input :exec_summary_intro, input_html: { rows: 4 },
+            hint: t('simple_form.hints.business_unit_type.exec_summary_intro',
+              keywords: I18n.t("conclusion_review.executive_summary.keywords.review")
+            ).html_safe %>
         </div>
         <div class="col-md-3">
           <%= f.input :independent_identification %>

--- a/config/locales/application.es.yml
+++ b/config/locales/application.es.yml
@@ -1239,6 +1239,7 @@ es:
         review_prefix: "Prefijo en el informe"
         recipients: "Destinatarios del informe"
         sectors: "Sectores/departamentos involucrados"
+        exec_summary_intro: 'Introducción de Resumen Ejecutivo'
         external: "Externo"
         require_tag: "Requerir etiqueta en informe"
         require_counts: "Requerir cantidades en objetivos de control"

--- a/config/locales/application.es.yml
+++ b/config/locales/application.es.yml
@@ -1551,6 +1551,10 @@ es:
           attributes:
             business_units:
               locked: "no pueden ser eliminadas, ya se utilizaron en al menos un plan de trabajo"
+            exec_summary_intro:
+              missing_keys:
+                one: "contiene una clave no válida: %{invalid_keys}. Las opciones son: %{valid_keys}"
+                other: "contiene %{count} claves no válidas: %{invalid_keys}. Las opciones son: %{valid_keys}"
         conclusion_final_review:
           attributes:
             review_id:

--- a/config/locales/application.es.yml
+++ b/config/locales/application.es.yml
@@ -1553,8 +1553,8 @@ es:
               locked: "no pueden ser eliminadas, ya se utilizaron en al menos un plan de trabajo"
             exec_summary_intro:
               missing_keys:
-                one: "contiene una clave no válida: %{invalid_keys}. Las opciones son: %{valid_keys}"
-                other: "contiene %{count} claves no válidas: %{invalid_keys}. Las opciones son: %{valid_keys}"
+                one: "contiene una clave no válida: %{invalid_keys}"
+                other: "contiene %{count} claves no válidas: %{invalid_keys}"
         conclusion_final_review:
           attributes:
             review_id:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -511,8 +511,10 @@
     executive_summary:
       title: "Resumen ejecutivo"
       review_author: "Gerencia de Auditoría Interna"
-      project: "La Auditoría practicada estuvo circunscripta a la revisión de:"
-      project_alt: "Conforme a lo previsto en la propuesta de Locación de Servicios Profesionales, aceptada en todos sus términos y condiciones por Naranja Digital Compañía Financiera S.A.U. con fecha 21 de Enero de 2021, presentamos el informe de Auditoria correspondiente al siguiente proceso:"
+      intro_default: "La Auditoría practicada estuvo circunscripta a la revisión de:"
+      intro_alt: "Conforme a lo previsto en la propuesta de Locación de Servicios Profesionales, aceptada en todos sus términos y condiciones por Naranja Digital Compañía Financiera S.A.U. con fecha 21 de Enero de 2021, presentamos el informe de Auditoria correspondiente al siguiente proceso:"
+      keywords:
+        review: 'informe'
       risk_exposure: "Exposición al riesgo del proceso evaluado: <b>%{risk}</b> (Fórmula algorítmica de la Matriz de Riesgos)"
       score: "Calificación"
       evolution: "EVOLUCIÓN (*)"

--- a/config/locales/simple_form.es.yml
+++ b/config/locales/simple_form.es.yml
@@ -54,3 +54,5 @@ es:
         password: 'Contraseña del usuario de servicio para la importación automática de usuarios'
       import:
         username: 'Usuario con permisos para consultar la base de usuarios LDAP'
+      business_unit_type:
+        exec_summary_intro: "Las clave válida a incluir es: <code>%{%{keywords}}</code>"

--- a/db/migrate/20230331034310_add_exec_summary_intro_to_business_unit_types.rb
+++ b/db/migrate/20230331034310_add_exec_summary_intro_to_business_unit_types.rb
@@ -1,0 +1,5 @@
+class AddExecSummaryIntroToBusinessUnitTypes < ActiveRecord::Migration[6.1]
+  def change
+    add_column :business_unit_types, :exec_summary_intro, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_09_05_172357) do
+ActiveRecord::Schema.define(version: 2023_03_31_034310) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
@@ -192,6 +192,7 @@ ActiveRecord::Schema.define(version: 2022_09_05_172357) do
     t.string "reviews_for"
     t.string "detailed_review"
     t.boolean "grouped_by_business_unit_annual_report", default: false
+    t.text "exec_summary_intro"
     t.index ["external"], name: "index_business_unit_types_on_external"
     t.index ["name"], name: "index_business_unit_types_on_name"
     t.index ["organization_id"], name: "index_business_unit_types_on_organization_id"

--- a/test/models/business_unit_type_test.rb
+++ b/test/models/business_unit_type_test.rb
@@ -109,4 +109,29 @@ class BusinessUnitTypeTest < ActiveSupport::TestCase
     assert @business_unit_type.invalid?
     assert_error @business_unit_type, :business_units, :locked
   end
+
+  # Prueba que las validaciones del modelo se cumplan como es esperado
+  test 'validates gal exec summary intro must have valid keys' do
+    set_organization
+
+    skip unless Current.conclusion_pdf_format == 'gal'
+
+    invalid_key  = 'inválida'
+    missing_keys = [invalid_key]
+    valid_key    = I18n.t "conclusion_review.executive_summary.keywords.review"
+
+    @business_unit_type.exec_summary_intro = "Prueba con key inválido: %{#{invalid_key}}"
+
+    assert @business_unit_type.invalid?
+    assert_error @business_unit_type, :exec_summary_intro, :missing_keys,
+      count: missing_keys.count, invalid_keys: missing_keys.to_sentence
+
+    @business_unit_type.exec_summary_intro = "Prueba con key válido: %{#{valid_key}}"
+    assert @business_unit_type.valid?
+
+  ensure
+    Current.organization = nil
+    Current.user         = nil
+  end
+
 end


### PR DESCRIPTION
- Crea el campo `exec_summary_intro` y lo agrega al `form` de las unidades organizativas (visible sólo para gal)
- Agrega `hint` al campo con las `keys` válidas
- Agregar lógica en el pdf para que:
  - Si el campo existe, se usa su contenido
  - Sino existe, pero `independent_identification` es `true`, se usa el `i18n` `intro_alt`
  - Sino se cumplen las condiciones anteriores, se usa el `i18n` `intro_default`
- Si el contenido de  `exec_summary_intro` incluye el key _informe_, lo reemplaza por el `identification` del `review` (en el PDF)
- Valida que en el campo solo se puedan incluir `keys` aceptadas para evitar un `KeyError`