### PR TITLE
MS-319_Fix_user_CSV_download_pagination_bug

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -115,21 +115,24 @@ class UsersController < ApplicationController
     end
 
     def users_data_csv
-      @users.preload(organization_roles: :role).map do |user|
-        [
-          user.user,
-          user.name,
-          user.last_name,
-          user.email,
-          user.function,
-          user.roles(@current_organization.id).map(&:name).join('; '),
-          user.parent&.full_name,
-          user.children.not_hidden.enabled.map(&:full_name).join(' / '),
-          I18n.t(user.enable? ? 'label.yes' : 'label.no'),
-          user.password_changed ? I18n.l(user.password_changed, format: :minimal) : '-',
-          user.last_access ? I18n.l(user.last_access, format: :minimal) : '-'
-        ]
-      end
+      @users
+        .unscope(:limit, :offset)
+        .preload(organization_roles: :role)
+        .map do |user|
+          [
+            user.user,
+            user.name,
+            user.last_name,
+            user.email,
+            user.function,
+            user.roles(@current_organization.id).map(&:name).join('; '),
+            user.parent&.full_name,
+            user.children.not_hidden.enabled.map(&:full_name).join(' / '),
+            I18n.t(user.enable? ? 'label.yes' : 'label.no'),
+            user.password_changed ? I18n.l(user.password_changed, format: :minimal) : '-',
+            user.last_access ? I18n.l(user.last_access, format: :minimal) : '-'
+          ]
+        end
     end
 
     def filter_text


### PR DESCRIPTION
Se eliminan los scopes `:limit` y `:offset` agregados por `will_paginate` para evitar que se limiten los registros en la descarga CSV de usuarios