### PR TITLE
MS-324_Fix_poll_search

### DIFF
--- a/app/models/concerns/polls/search.rb
+++ b/app/models/concerns/polls/search.rb
@@ -19,6 +19,6 @@ module Polls::Search
         regexp:            /\Asi|no\z/i,
         conversion_method: ->(value) { value.downcase == 'si' }
       }
-    }
+    }.with_indifferent_access
   end
 end


### PR DESCRIPTION
Se agrega el método [`with_indifferent_access`](https://apidock.com/rails/Hash/with_indifferent_access) a la constante `COLUMNS_FOR_SEARCH`