### PR TITLE
Fix/change start and end date in bic conclusion review

### DIFF
--- a/app/helpers/conclusion_reviews/bic_pdf/conclusion_review_helper.rb
+++ b/app/helpers/conclusion_reviews/bic_pdf/conclusion_review_helper.rb
@@ -50,13 +50,23 @@ module ConclusionReviews::BicPdf::ConclusionReviewHelper
     end
   end
 
-  def bic_review_period conclusion_review
-    plan_item_start = I18n.l conclusion_review.plan_item.start, format: :minimal
-    plan_item_end   = I18n.l conclusion_review.plan_item.end, format: :minimal
+  def bic_internal_audit_review_dates conclusion_review
+    start_date = bic_internal_audit_review_start_date conclusion_review
+    end_date   = bic_internal_audit_review_end_date conclusion_review
 
-    I18n.t 'conclusion_review.bic.cover.review_period_description',
-           plan_item_start: plan_item_start,
-           plan_item_end: plan_item_end
+    I18n.t 'conclusion_review.bic.cover.internal_audit_review_dates',
+      start_date: start_date,
+      end_date: end_date
+  end
+
+  def bic_internal_audit_review_start_date conclusion_review
+    date = conclusion_review.review.opening_interview&.start_date
+
+    date ? I18n.l(date, format: :minimal) : '--/--/--'
+  end
+
+  def bic_internal_audit_review_end_date conclusion_review
+    I18n.l conclusion_review.issue_date, format: :minimal
   end
 
   def bic_weakness_responsible weakness

--- a/app/views/conclusion_reviews/bic_pdf/conclusion_review.html.erb
+++ b/app/views/conclusion_reviews/bic_pdf/conclusion_review.html.erb
@@ -56,7 +56,7 @@
         <div class="row">
           <div class="col-10 offset-1">
             <p class="fs-bice-3"><span class="fw-bold"><%= ConclusionReview.human_attribute_name :previous_identification %></span> <%= bic_previous_review_text conclusion_review %></p>
-            <p class="pt-4 fs-bice-3"><span class="fw-bold"><%= I18n.t 'conclusion_review.bic.cover.review_period_title' %></span> <%= bic_review_period conclusion_review %></p>
+            <p class="pt-4 fs-bice-3"><span class="fw-bold"><%= I18n.t 'conclusion_review.bic.cover.internal_audit_review' %></span> <%= bic_internal_audit_review_dates conclusion_review %></p>
           </div>
         </div>
         <div class="row pt-5">

--- a/config/locales/conclusion_reviews.en.yml
+++ b/config/locales/conclusion_reviews.en.yml
@@ -17,8 +17,8 @@ en:
         final_with_weaknesses: 'Attached to this document, we distribute the final version of the referenced audit report, which includes responses from each area.'
         final_without_weaknesses: 'Attached to this document, we distribute the Final version of the referenced audit report, which does not contain relevant issues.'
         recipients: 'Recipients'
-        review_period_title: "Internal Audit Review:"
-        review_period_description: "Started: %{plan_item_start} - Completed: %{plan_item_end}"
+        internal_audit_review: "Internal Audit Review:"
+        internal_audit_review_dates: "Started: %{start_date} - Completed: %{end_date}"
       scope: 'SCOPE'
       audit_comments: 'AUDIT COMMENTS'
       weaknesses:

--- a/config/locales/conclusion_reviews.es.yml
+++ b/config/locales/conclusion_reviews.es.yml
@@ -16,8 +16,8 @@ es:
         final_with_weaknesses: 'Adjunto al presente distribuimos la versión Final del Informe de referencia conteniendo las respuestas de cada una de las áreas.'
         final_without_weaknesses: 'Adjunto al presente distribuimos la versión Final del Informe de referencia, el que no contiene observaciones de relevancia que formular.'
         recipients: 'Destinatarios'
-        review_period_title: "Revisión de Auditoría Interna:"
-        review_period_description: "Iniciada: %{plan_item_start} - Finalizada: %{plan_item_end}"
+        internal_audit_review: "Revisión de Auditoría Interna:"
+        internal_audit_review_dates: "Iniciada: %{start_date} - Finalizada: %{end_date}"
       scope: 'ALCANCE'
       audit_comments: 'COMENTARIOS DE AUDITORIA'
       weaknesses:

--- a/test/helpers/conclusion_reviews/bic_pdf/conclusion_review_helper_test.rb
+++ b/test/helpers/conclusion_reviews/bic_pdf/conclusion_review_helper_test.rb
@@ -108,16 +108,16 @@ class ConclusionReviews::BicPdf::ConclusionReviewHelperTest < ActionView::TestCa
     assert_equal '-', bic_previous_review_text(conclusion_review)
   end
 
-  test 'get bic review period' do
-    conclusion_review = conclusion_reviews :conclusion_current_final_review
-    plan_item_start   = I18n.l conclusion_review.plan_item.start, format: :minimal
-    plan_item_end     = I18n.l conclusion_review.plan_item.end, format: :minimal
+  test 'get bic internal audit review dates' do
+    conclusion_review      = conclusion_reviews :conclusion_current_final_review
+    opening_interview_date = conclusion_review.review.opening_interview&.start_date
+    start_date             = opening_interview_date ? I18n.l(opening_interview_date, format: :minimal) : '--/--/--'
+    end_date               = I18n.l conclusion_review.issue_date, format: :minimal
+    result                 = I18n.t 'conclusion_review.bic.cover.internal_audit_review_dates',
+                               start_date: start_date,
+                               end_date: end_date
 
-    result = I18n.t 'conclusion_review.bic.cover.review_period_description',
-                    plan_item_start: plan_item_start,
-                    plan_item_end: plan_item_end
-
-    assert_equal result, bic_review_period(conclusion_review)
+    assert_equal result, bic_internal_audit_review_dates(conclusion_review)
   end
 
   test 'get bic weakness responsible when dont have process owner' do


### PR DESCRIPTION
En el PR https://github.com/cirope/mawidabp/pull/514, se actualizó el formato del informe y se migró de `prawn` a `wicked_pdf`. Pero también se cambiaron las fechas de inicio y fin de la revisión por las de inicio y fin del `plan_item`. El cliente solicitó que se volvieran a utilizar las fechas anteriores.