### PR TITLE
Fix/Adjust Review PDF column widths

### DIFF
--- a/app/models/concerns/reviews/pdf.rb
+++ b/app/models/concerns/reviews/pdf.rb
@@ -73,14 +73,36 @@ module Reviews::Pdf
     end
 
     def pdf_columns
+      hide_effects          = HIDE_CONTROL_EFFECTS
+      hide_compliance_tests = HIDE_CONTROL_COMPLIANCE_TESTS
+
+      design_tests_width = if hide_effects && hide_compliance_tests
+                             35
+                           elsif hide_effects
+                             25
+                           elsif hide_compliance_tests
+                             30
+                           else
+                             20
+                           end
+
+      sustantive_tests_width = if hide_effects && hide_compliance_tests
+                                 35
+                               elsif hide_effects
+                                 20
+                               elsif hide_compliance_tests
+                                 30
+                               else
+                                 20
+                               end
       [
         [ProcessControl.model_name.human, 6],
         [ControlObjective.model_name.human, 6],
         ([Control.human_attribute_name('effects'), 10] unless HIDE_CONTROL_EFFECTS),
         [Control.human_attribute_name('control'), 10],
-        [Control.human_attribute_name('design_tests'), HIDE_CONTROL_EFFECTS ? 35 : 20],
+        [Control.human_attribute_name('design_tests'), design_tests_width],
         ([Control.human_attribute_name('compliance_tests'), 20] unless HIDE_CONTROL_COMPLIANCE_TESTS),
-        [Control.human_attribute_name('sustantive_tests'), HIDE_CONTROL_COMPLIANCE_TESTS ? 35 : 20],
+        [Control.human_attribute_name('sustantive_tests'), sustantive_tests_width],
         [ControlObjectiveItem.human_attribute_name('auditor_comment'), 8]
       ].compact
     end

--- a/app/models/concerns/reviews/pdf.rb
+++ b/app/models/concerns/reviews/pdf.rb
@@ -89,7 +89,7 @@ module Reviews::Pdf
       sustantive_tests_width = if hide_effects && hide_compliance_tests
                                  35
                                elsif hide_effects
-                                 20
+                                 25
                                elsif hide_compliance_tests
                                  30
                                else

--- a/app/models/concerns/reviews/pdf.rb
+++ b/app/models/concerns/reviews/pdf.rb
@@ -73,33 +73,24 @@ module Reviews::Pdf
     end
 
     def pdf_columns
-      design_tests_width = if HIDE_CONTROL_EFFECTS && HIDE_CONTROL_COMPLIANCE_TESTS
-                             35
-                           elsif HIDE_CONTROL_EFFECTS
-                             25
-                           elsif HIDE_CONTROL_COMPLIANCE_TESTS
-                             30
-                           else
-                             20
-                           end
+      tests_width = if HIDE_CONTROL_EFFECTS && HIDE_CONTROL_COMPLIANCE_TESTS
+                      35
+                    elsif HIDE_CONTROL_EFFECTS
+                      25
+                    elsif HIDE_CONTROL_COMPLIANCE_TESTS
+                      30
+                    else
+                      20
+                    end
 
-      sustantive_tests_width = if HIDE_CONTROL_EFFECTS && HIDE_CONTROL_COMPLIANCE_TESTS
-                                 35
-                               elsif HIDE_CONTROL_EFFECTS
-                                 25
-                               elsif HIDE_CONTROL_COMPLIANCE_TESTS
-                                 30
-                               else
-                                 20
-                               end
       [
         [ProcessControl.model_name.human, 6],
         [ControlObjective.model_name.human, 6],
         ([Control.human_attribute_name('effects'), 10] unless HIDE_CONTROL_EFFECTS),
         [Control.human_attribute_name('control'), 10],
-        [Control.human_attribute_name('design_tests'), design_tests_width],
+        [Control.human_attribute_name('design_tests'), tests_width],
         ([Control.human_attribute_name('compliance_tests'), 20] unless HIDE_CONTROL_COMPLIANCE_TESTS),
-        [Control.human_attribute_name('sustantive_tests'), sustantive_tests_width],
+        [Control.human_attribute_name('sustantive_tests'), tests_width],
         [ControlObjectiveItem.human_attribute_name('auditor_comment'), 8]
       ].compact
     end

--- a/app/models/concerns/reviews/pdf.rb
+++ b/app/models/concerns/reviews/pdf.rb
@@ -73,24 +73,21 @@ module Reviews::Pdf
     end
 
     def pdf_columns
-      hide_effects          = HIDE_CONTROL_EFFECTS
-      hide_compliance_tests = HIDE_CONTROL_COMPLIANCE_TESTS
-
-      design_tests_width = if hide_effects && hide_compliance_tests
+      design_tests_width = if HIDE_CONTROL_EFFECTS && HIDE_CONTROL_COMPLIANCE_TESTS
                              35
-                           elsif hide_effects
+                           elsif HIDE_CONTROL_EFFECTS
                              25
-                           elsif hide_compliance_tests
+                           elsif HIDE_CONTROL_COMPLIANCE_TESTS
                              30
                            else
                              20
                            end
 
-      sustantive_tests_width = if hide_effects && hide_compliance_tests
+      sustantive_tests_width = if HIDE_CONTROL_EFFECTS && HIDE_CONTROL_COMPLIANCE_TESTS
                                  35
-                               elsif hide_effects
+                               elsif HIDE_CONTROL_EFFECTS
                                  25
-                               elsif hide_compliance_tests
+                               elsif HIDE_CONTROL_COMPLIANCE_TESTS
                                  30
                                else
                                  20


### PR DESCRIPTION
Antes, si `HIDE_CONTROL_EFFECTS` y `HIDE_CONTROL_COMPLIANCE_TESTS` eran ambos verdaderos o ambos falsos, el PDF se generaba correctamente con un ancho total de columnas de 100. Sin embargo, cuando los valores de estas variables se mezclaban (uno verdadero y el otro falso), el PDF resultante tenía un ancho que excedía la página (105) o un ancho insuficiente (95).

Ahora, los anchos de las columnas se determinan dinámicamente en función de los valores de `HIDE_CONTROL_EFFECTS` y `HIDE_CONTROL_COMPLIANCE_TESTS`, asegurando que el total de los anchos siempre sume 100. Aunque la lógica es un poco más compleja que antes, nos aseguramos de que los anchos de las columnas similares sean consistentes y no haya diferencias notables como sucedía anteriormente.

Efecto oculto y Cumplimiento oculto
![image](https://github.com/cirope/mawidabp/assets/36643035/a8bd8dd1-5660-4b0d-a8a0-0ea718d55f1e)

Efecto visible y Cumplimiento oculto
![image](https://github.com/cirope/mawidabp/assets/36643035/1c9d69b9-143b-4c61-8445-0fdc11a42ee4)

Efecto oculto y Cumplimiento visible
![image](https://github.com/cirope/mawidabp/assets/36643035/75aa8ed5-9bb7-4743-bcb1-94287d2c9396)

Efecto visible y Cumplimiento visible
![image](https://github.com/cirope/mawidabp/assets/36643035/54e01b5a-efcb-4904-8737-7040e24b19d6)

