### PR TITLE
Fix CSV for findings with hidden effect

### DIFF
--- a/app/models/concerns/findings/csv.rb
+++ b/app/models/concerns/findings/csv.rb
@@ -27,7 +27,7 @@ module Findings::Csv
       full_state_text,
       try(:risk_text) || '',
       (respond_to?(:risk_text) ? priority_text : '' unless USE_SCOPE_CYCLE),
-      effect,
+      effect || '',
       auditeds_as_process_owner.join('; '),
       audited_users.join('; '),
       auditor_users.join('; '),


### PR DESCRIPTION
Corrige el error en la generación del `CSV` de `findings` para organizaciones que tienen el campo `effect` oculto. El problema se generaba cuando este campo estaba `nil` y luego se aplicaba un `compact`, lo que causaba el desplazamiento de los valores del resto de las columnas.