### PR TITLE
Fix font size difference in HTML lists for Bic PDF

### DIFF
--- a/app/assets/stylesheets/pdf/bic_pdf.scss
+++ b/app/assets/stylesheets/pdf/bic_pdf.scss
@@ -95,6 +95,6 @@ div.nobreak { page-break-inside: avoid; }
   font-size: 2.5rem !important;
 }
 
-.fs-bice-3 {
+.fs-bice-3, ul, li {
   font-size: 1.7rem !important;
 }


### PR DESCRIPTION
Optimiza la declaración CSS para los tamaños de fuente, asegurando consistencia entre el texto del input y los textos utilizados dentro de listas en el mismo input. Esto evita que el texto de las listas sea más pequeño que el resto del texto.