### PR TITLE
Chore/Add simplecov

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ config/application.yml
 config/jekyll/_vendor/bundle/
 config/jekyll/_sass/stylesheets
 config/jekyll/assets/fonts
+
+# Ignore simplecov
+coverage

--- a/Gemfile
+++ b/Gemfile
@@ -76,6 +76,7 @@ end
 
 group :test do
   gem 'timecop'
+  gem 'simplecov', require: false
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,6 +119,7 @@ GEM
     disposable (0.6.3)
       declarative (>= 0.0.9, < 1.0.0)
       representable (>= 3.1.1, < 4)
+    docile (1.4.1)
     ed25519 (1.3.0)
     erubi (1.13.0)
     execjs (2.7.0)
@@ -312,6 +313,12 @@ GEM
     simple_form (5.3.1)
       actionpack (>= 5.2)
       activemodel (>= 5.2)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.1)
+    simplecov_json_formatter (0.1.4)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -435,6 +442,7 @@ DEPENDENCIES
   sassc-rails
   sidekiq (< 7)
   simple_form
+  simplecov
   terser
   timecop
   unicorn

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,6 @@
+require 'simplecov'
+SimpleCov.start 'rails'
+
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
 require 'sidekiq/testing'


### PR DESCRIPTION
Este PR agrega la gema `simplecov`. 

`SimpleCov` es una herramienta que permite medir el porcentaje de cobertura de código de las pruebas automatizadas y ayuda a identificar qué partes del código no están siendo testeadas.