### PR TITLE
Autocomplete work_scope field in final review form

### DIFF
--- a/app/views/conclusion_final_reviews/new.js.erb
+++ b/app/views/conclusion_final_reviews/new.js.erb
@@ -19,6 +19,7 @@
   $('#conclusion_final_review_reference').val('<%== j @conclusion_final_review.reference %>')
   $('#conclusion_final_review_scope').val('<%== j @conclusion_final_review.scope %>')
   $('#conclusion_final_review_main_recommendations').val('<%== j @conclusion_final_review.main_recommendations %>')
+  $('#conclusion_final_review_work_scope').val('<%== j @conclusion_final_review.work_scope %>')
   $('#conclusion_final_review_additional_comments').val('<%== j @conclusion_final_review.additional_comments %>')
   $('#conclusion_final_review_review_conclusion').val('<%== j @conclusion_final_review.review_conclusion %>')
   $('#conclusion_final_review_applied_data_analytics').val('<%== j @conclusion_final_review.applied_data_analytics %>')
@@ -52,6 +53,7 @@
     'reference',
     'scope',
     'main_recommendations',
+    'work_scope',
     'additional_comments',
     'review_conclusion',
     'applied_data_analytics'


### PR DESCRIPTION
Se agrega el campo `work_scope` para permitir que se autocomplete y se resetee el campo en el formulario del informe definitivo.