### PR TITLE
Set work_scope as textarea in final review form

### DIFF
--- a/app/views/conclusion_draft_reviews/_form.html.erb
+++ b/app/views/conclusion_draft_reviews/_form.html.erb
@@ -58,7 +58,7 @@
               <%= f.input :recipients, input_html: { rows: USE_SCOPE_CYCLE ? 2 : 4 } %>
 
               <% if USE_SCOPE_CYCLE %>
-                <%= f.input :work_scope %>
+                <%= f.input :work_scope, as: :text, input_html: { rows: 3 } %>
                 <%= f.input :additional_comments, input_html: { rows: 2 } %>
               <% end %>
             <% else %>

--- a/app/views/conclusion_final_reviews/_form.html.erb
+++ b/app/views/conclusion_final_reviews/_form.html.erb
@@ -63,7 +63,7 @@
               <%= f.input :recipients, input_html: { readonly: readonly, rows: USE_SCOPE_CYCLE ? 2 : 4 } %>
 
               <% if USE_SCOPE_CYCLE %>
-                <%= f.input :work_scope, input_html: { readonly: readonly } %>
+                <%= f.input :work_scope, as: :text, input_html: { readonly: readonly, rows: 3 } %>
                 <%= f.input :additional_comments, input_html: { readonly: readonly, rows: 2 } %>
               <% end %>
 


### PR DESCRIPTION
Se cambió el campo `work_scope` en los formularios del `final review` para que se muestren como un `textarea`