### PR TITLE
Always replace workpaper name with filename

### DIFF
--- a/app/assets/javascripts/work_papers.js
+++ b/app/assets/javascripts/work_papers.js
@@ -40,7 +40,7 @@ jQuery(function ($) {
     var fileName   = $fileInput.val().split('\\').pop()
     var $nameField = $fileInput.closest('.work_paper').find('input[name*="[name]"]')
 
-    if (fileName && $nameField.val() === '') {
+    if (fileName) {
       $nameField.val(fileName)
     }
   })


### PR DESCRIPTION
Se modifica el comportamiento del script desarrollado en #898 para que el campo de nombre se autocomplete con el nombre del archivo cargado, incluso si el campo ya tiene contenido.