### PR TITLE
Add readonly logic for review user assignments

### DIFF
--- a/app/models/concerns/reviews/users.rb
+++ b/app/models/concerns/reviews/users.rb
@@ -30,6 +30,15 @@ module Reviews::Users
     can_be_modified
   end
 
+  def user_assignments_readonly?
+    return false unless Current.organization.require_plan_and_review_approval?
+
+    assignment_type = review_assignment_type
+    plan_approved   = plan_item&.plan&.approved?
+
+    plan_approved && ![:manager, :supervisor].include?(ReviewUserAssignment::TYPES.invert[assignment_type])
+  end
+
   private
 
     def review_assignment_type

--- a/app/models/concerns/reviews/users.rb
+++ b/app/models/concerns/reviews/users.rb
@@ -33,10 +33,11 @@ module Reviews::Users
   def user_assignments_readonly?
     return false unless Current.organization.require_plan_and_review_approval?
 
-    assignment_type = review_assignment_type
-    plan_approved   = plan_item&.plan&.approved?
+    manager_or_supervisor = [:manager, :supervisor].include?(
+      ReviewUserAssignment::TYPES.invert[review_assignment_type]
+    )
 
-    plan_approved && ![:manager, :supervisor].include?(ReviewUserAssignment::TYPES.invert[assignment_type])
+    approved? && !manager_or_supervisor
   end
 
   private

--- a/app/views/reviews/_form.html.erb
+++ b/app/views/reviews/_form.html.erb
@@ -170,7 +170,7 @@
       </div>
 
       <div id="review_user_assignments">
-        <% audit_team, others = @review.review_user_assignments.partition(&:in_audit_team?) %>
+        <% audit_team, others = @review.review_user_assignments.partition &:in_audit_team? %>
 
         <% if audit_team.present? %>
           <h5 class="text-muted"><%= t 'review.user_assignment.audit_team' %></h5>

--- a/app/views/reviews/_form.html.erb
+++ b/app/views/reviews/_form.html.erb
@@ -1,6 +1,6 @@
-<% readonly = @review.has_final_review? %>
+<% readonly                  = @review.has_final_review? %>
 <% user_assignments_readonly = readonly || @review.user_assignments_readonly? %>
-<% frozen = @review.is_frozen? %>
+<% frozen                    = @review.is_frozen? %>
 
 <div class="card">
   <div class="card-body">

--- a/app/views/reviews/_form.html.erb
+++ b/app/views/reviews/_form.html.erb
@@ -1,4 +1,5 @@
 <% readonly = @review.has_final_review? %>
+<% user_assignments_readonly = readonly || @review.user_assignments_readonly? %>
 <% frozen = @review.is_frozen? %>
 
 <div class="card">
@@ -169,13 +170,13 @@
       </div>
 
       <div id="review_user_assignments">
-        <% audit_team, others = @review.review_user_assignments.partition &:in_audit_team? %>
+        <% audit_team, others = @review.review_user_assignments.partition(&:in_audit_team?) %>
 
         <% if audit_team.present? %>
           <h5 class="text-muted"><%= t 'review.user_assignment.audit_team' %></h5>
 
           <%= f.simple_fields_for :review_user_assignments, audit_team do |rua_f| %>
-            <%= render 'review_user_assignment', f: rua_f, readonly: readonly %>
+            <%= render 'review_user_assignment', f: rua_f, readonly: user_assignments_readonly %>
           <% end %>
         <% end %>
 
@@ -183,17 +184,17 @@
           <h5 class="text-muted"><%= t 'review.user_assignment.others' %></h5>
 
           <%= f.simple_fields_for :review_user_assignments, others do |rua_f| %>
-            <%= render 'review_user_assignment', f: rua_f, readonly: readonly %>
+            <%= render 'review_user_assignment', f: rua_f, readonly: user_assignments_readonly %>
           <% end %>
         <% end %>
 
-        <% unless readonly %>
+        <% unless user_assignments_readonly %>
           <hr>
 
           <div data-review-user-assignments-container></div>
 
           <%= link_to_add_fields(
-            t('review.add_user_assignment'), f, :review_user_assignments, nil, {}, { readonly: readonly }
+            t('review.add_user_assignment'), f, :review_user_assignments, nil, {}, { readonly: user_assignments_readonly }
           ) %>
         <% end %>
       </div>


### PR DESCRIPTION
Se agregó lógica para establecer los campos de asignación de usuarios del informe (`review_user_assignments`) en modo solo lectura cuando:

- El `review` está aprobado.
- El usuario actual no tiene el `assignment_type` de `manager` o `supervisor`.
- La organización tiene habilitada la configuración `plan_and_review_approval`.

La lógica combina esta nueva validación con el estado general de solo lectura del review (`readonly`).
