### PR TITLE
Rename finding state names

### DIFF
--- a/config/locales/application.es.yml
+++ b/config/locales/application.es.yml
@@ -370,7 +370,7 @@ es:
       being_implemented: "'En progreso' al %{date}"
       created: "'Dadas de alta' entre el %{from_date} y el %{to_date}"
       empty: Sin observaciones para el filtro aplicado.
-      implemented: "'Implementadas' entre el %{from_date} y el %{to_date}"
+      implemented: "'Implementados' entre el %{from_date} y el %{to_date}"
       pdf_name: observaciones_informes_definitivos_por_riesgo_y_unidades_de_negocio_%{from_date}_al_%{to_date}.pdf
       period_summary: Resumen del periodo %{period}
       title: |-
@@ -1284,7 +1284,7 @@ es:
       being_implemented: "'En progreso' al %{date}"
       created: "'Dadas de alta' entre el %{from_date} y el %{to_date}"
       empty: Sin observaciones para el filtro aplicado.
-      implemented: "'Implementadas' entre el %{from_date} y el %{to_date}"
+      implemented: "'Implementados' entre el %{from_date} y el %{to_date}"
       pdf_name: observaciones_seguimiento_por_riesgo_y_unidades_de_negocio_%{from_date}_al_%{to_date}.pdf
       period_summary: Resumen del periodo %{period}
       title: |-

--- a/config/locales/application.es.yml
+++ b/config/locales/application.es.yml
@@ -367,7 +367,7 @@ es:
         TOTALES POR NIVEL DE RIESGO
       total: TOTAL
     weaknesses_by_risk_and_business_unit:
-      being_implemented: "'En proceso de implementación' al %{date}"
+      being_implemented: "'En progreso' al %{date}"
       created: "'Dadas de alta' entre el %{from_date} y el %{to_date}"
       empty: Sin observaciones para el filtro aplicado.
       implemented: "'Implementadas' entre el %{from_date} y el %{to_date}"
@@ -1281,7 +1281,7 @@ es:
         TOTALES POR NIVEL DE RIESGO
       total: TOTAL
     weaknesses_by_risk_and_business_unit:
-      being_implemented: "'En proceso de implementación' al %{date}"
+      being_implemented: "'En progreso' al %{date}"
       created: "'Dadas de alta' entre el %{from_date} y el %{to_date}"
       empty: Sin observaciones para el filtro aplicado.
       implemented: "'Implementadas' entre el %{from_date} y el %{to_date}"

--- a/config/locales/mailer.es.yml
+++ b/config/locales/mailer.es.yml
@@ -25,8 +25,8 @@ es:
 
   notifier:
     being_implemented_and_stale_finding_to_manager:
-      the_following_finding_is_being_implemented_and_stale: La fecha de implementación de la siguiente observación ha vencido y todavía se encuentra en proceso de implementación
-      title: Notificación de observaciones en proceso de implementación vencidas
+      the_following_finding_is_being_implemented_and_stale: La fecha de implementación de la siguiente observación ha vencido y todavía se encuentra en progreso
+      title: Notificación de observaciones en progreso vencidas
     change_password: Cambiar contraseña
     changes_notification:
       title: Notificación de cambios

--- a/config/locales/models.es.yml
+++ b/config/locales/models.es.yml
@@ -303,7 +303,7 @@ es:
         frequency: Frecuencia
         impact_amount: Monto universo
         impact_risk: Impacto
-        implemented_at: Fecha de cambio a "Implementada"
+        implemented_at: Fecha de cambio a "Implementado"
         manual_risk: Manual
         nobs: N_Obs
         nsisio: N_SISAC
@@ -909,7 +909,7 @@ es:
         follow_up_date: Fecha de implementación
         impact: Impacto
         impact_risk: Impacto
-        implemented_at: Fecha de cambio a "Implementada"
+        implemented_at: Fecha de cambio a "Implementado"
         internal_control_components: Componentes de CI
         manual_risk: Manual
         nobs: N_Obs

--- a/config/locales/views.es.yml
+++ b/config/locales/views.es.yml
@@ -196,7 +196,7 @@ es:
       criteria_mismatch: Difiere criterio
       expired: Desestimada / No aplica
       failure: Falla
-      implemented: Implementada
+      implemented: Implementado
       implemented_audited: Implementada / Auditada
       incomplete: Abierto
       notify: Notificar

--- a/config/locales/views.es.yml
+++ b/config/locales/views.es.yml
@@ -198,7 +198,7 @@ es:
       failure: Falla
       implemented: Implementada
       implemented_audited: Implementada / Auditada
-      incomplete: Incompleta
+      incomplete: Abierto
       notify: Notificar
       repeated: Reiterada
       revoked: Anulada

--- a/config/locales/views.es.yml
+++ b/config/locales/views.es.yml
@@ -194,7 +194,7 @@ es:
       being_implemented_stale_rescheduled: Reprogramada vencida
       confirmed: Confirmada
       criteria_mismatch: Difiere criterio
-      expired: Desestimada / No aplica
+      expired: Cerrado - No aplica más tiempo
       failure: Falla
       implemented: Implementado
       implemented_audited: Cerrado - Verificado

--- a/config/locales/views.es.yml
+++ b/config/locales/views.es.yml
@@ -186,7 +186,7 @@ es:
       title: Detalles del hallazgo
     state:
       assumed_risk: Cerrado - La administración acepta el riesgo
-      awaiting: A regularizar
+      awaiting: Pendiente
       being_implemented: En progreso
       being_implemented_current: Vigente
       being_implemented_current_rescheduled: Reprogramada vigente

--- a/config/locales/views.es.yml
+++ b/config/locales/views.es.yml
@@ -187,7 +187,7 @@ es:
     state:
       assumed_risk: Riesgo asumido
       awaiting: A regularizar
-      being_implemented: En proceso de implementación
+      being_implemented: En progreso
       being_implemented_current: Vigente
       being_implemented_current_rescheduled: Reprogramada vigente
       being_implemented_stale: Vencida

--- a/config/locales/views.es.yml
+++ b/config/locales/views.es.yml
@@ -185,7 +185,7 @@ es:
     show:
       title: Detalles del hallazgo
     state:
-      assumed_risk: Riesgo asumido
+      assumed_risk: Cerrado - La administración acepta el riesgo
       awaiting: A regularizar
       being_implemented: En progreso
       being_implemented_current: Vigente

--- a/config/locales/views.es.yml
+++ b/config/locales/views.es.yml
@@ -197,7 +197,7 @@ es:
       expired: Desestimada / No aplica
       failure: Falla
       implemented: Implementado
-      implemented_audited: Implementada / Auditada
+      implemented_audited: Cerrado - Verificado
       incomplete: Abierto
       notify: Notificar
       repeated: Reiterada


### PR DESCRIPTION
Se renombraron los estados según lo solicitado por el cliente:

- `Incompleta` -> `Abierto`
- `En proceso de implementación` -> `En progreso`
- `Implementada` -> `Implementado`
- `Implementada / Auditada` -> `Cerrado - Verificado`
- `Desestimada` -> `Cerrado - No aplica más tiempo`
- `Riesgo asumido` -> `Cerrado - La administración acepta el riesgo`
- `A regularizar` -> `Pendiente`

_Aclaraciones_: 

- En vez de `Cerrada - Verificado` se utilizó `Cerrado - Verificado` para que sea coherente con el resto de los estados (`Cerrado - No aplica más tiempo` y `Cerrado - La administración acepta el riesgo`).
- En el i18n `notify_implemented_finding_with_follow_up_date_last_changed_greater_than_90_days.title`, el estado "implementada" no se cambio a masculino porque es un adjetivo.